### PR TITLE
fix: actions sync failed

### DIFF
--- a/.github/workflows/templates-sync.yml
+++ b/.github/workflows/templates-sync.yml
@@ -47,7 +47,7 @@ jobs:
         id: all-configs
         if: steps.changed-files.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
         run: |
-          all_configs=`find repos -type f | grep json`
+          all_configs=`find repos -type f | grep json | xargs`
           echo all configs $all_configs
           echo "::set-output name=ALL_CONFIGS::$all_configs"
       - name: Sync changed files


### PR DESCRIPTION
sync failed when change file "repos/linuxdeepin/.gitkeep"
limit sync action's suffix

Log: