### PR TITLE
fix: 项目管理同步失败

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -6,19 +6,17 @@ settings:
         enable: false
       wiki:
         enable: true
-      projects:
-        enable: true
     branches:
       master:
         dismiss_stale_reviews: true
-        enforce_admins: true
+        enforce_admins: false
         required_approving_review_count: 1
         required_status_checks:
           require_review: true
           strict: true
       uos:
         dismiss_stale_reviews: true
-        enforce_admins: true
+        enforce_admins: false
         required_approving_review_count: 1
         required_status_checks:
           require_review: true


### PR DESCRIPTION
project无法开启,暂时去掉
分支保护排除管理员,以便于机器人推送