### PR TITLE
fix: 开源实习生 changed to Students

### DIFF
--- a/teams.yaml
+++ b/teams.yaml
@@ -131,7 +131,7 @@ teams:
       - tsic404
       - zzxyb
       - cccccccb
-  - name: 开源实习生
+  - name: Students
     members:
       - avltreeql
       - baozidai
@@ -172,3 +172,4 @@ teams:
       - lxl690
       - alivezhy
       - ariZhou
+      - peeweep


### PR DESCRIPTION
changed name to Students and add peeweep to team

Log: change team name to Students