### PR TITLE
chore: add member as a maintainer of deepin-font-manager

### DIFF
--- a/teams.yaml
+++ b/teams.yaml
@@ -53,6 +53,7 @@ teams:
     members:
       - zccrs
       - LiuLibang
+      - HuiHui97520
     repositories_permissions:
       maintain:
         - deepin-font-manager


### PR DESCRIPTION
Add HuiHui97520 as a maintainer of deepin-font-manager

Log: 增加 HuiHui97520 作为字体管理器项目的维护人员