### PR TITLE
fix: teams.yaml for deepin-face team

### DIFF
--- a/teams.yaml
+++ b/teams.yaml
@@ -212,23 +212,23 @@ teams:
       maintain:
         - deepin-system-monitor
   - name: deepin-face
-      parent_team: Maintainers
-      members:
-        - zccrs
-        - kegechen
-        - robertkill
-      repositories_permissions:
-        maintain:
-          - deepin-face
-          - seetaface-tracker
-          - seetaface-tennis
-          - seetaface-recognizer
-          - seetaface-quality-assessor
-          - seetaface-pose-estimation
-          - seetaface-open-role-zoo
-          - seetaface-models
-          - seetaface-landmarker
-          - seetaface-boxes
-          - seetaface-authorize
-          - seetaface-anti-spoofing-x
-          - seetaface-age-predictor
+    parent_team: Maintainers
+    members:
+      - zccrs
+      - kegechen
+      - robertkill
+    repositories_permissions:
+      maintain:
+        - deepin-face
+        - seetaface-tracker
+        - seetaface-tennis
+        - seetaface-recognizer
+        - seetaface-quality-assessor
+        - seetaface-pose-estimation
+        - seetaface-open-role-zoo
+        - seetaface-models
+        - seetaface-landmarker
+        - seetaface-boxes
+        - seetaface-authorize
+        - seetaface-anti-spoofing-x
+        - seetaface-age-predictor


### PR DESCRIPTION
修复 teams.yaml 中的 deepin-face 一组配置

相关：https://github.com/linuxdeepin/.github/pull/85

Log: 修复 teams.yaml 中的 deepin-face 一组配置