### PR TITLE
fix: Merge does not trigger other workflows

### DIFF
--- a/.github/workflows/call-chatOps.yml
+++ b/.github/workflows/call-chatOps.yml
@@ -6,3 +6,5 @@ on:
 jobs:
   chatopt:
     uses: linuxdeepin/.github/.github/workflows/chatOps.yml@master
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/chatOps.yml
+++ b/.github/workflows/chatOps.yml
@@ -1,6 +1,13 @@
 name: chatOps
 on:
   workflow_call:
+    secrets:
+      APP_PRIVATE_KEY:
+        required: true
+
+env:
+  APP_ID: 174141
+  APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
 jobs:
   chatopt:
@@ -67,12 +74,43 @@ jobs:
               labels: ['approve']
             })
 
+      - name: install depends for load scripts
+        if: contains(github.event.comment.body, '/merge')
+        run: |
+          npm install @octokit/rest
+          npm install @octokit/auth-app
+      - name: Get token using github-script
+        if: contains(github.event.comment.body, '/merge')
+        id: get-token
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { Octokit } = require("@octokit/rest");
+            const { createAppAuth } = require("@octokit/auth-app");
+            const appOctokit = new Octokit({
+              authStrategy: createAppAuth,
+              auth: {
+                appId: process.env.APP_ID,
+                privateKey: process.env.APP_PRIVATE_KEY,
+              }
+            });
+            const app_installation = await appOctokit.rest.apps.getRepoInstallation({
+              owner: context.payload.organization.login,
+              repo: context.payload.repository.name
+            });
+            const { token } = await appOctokit.auth({
+              type: "installation",
+              installationId: app_installation.data.id
+            });
+            core.setOutput('app_token', token)
+
       - name: merge
         uses: actions/github-script@v5
         if: contains(github.event.comment.body, '/merge')
         env:
           REF: ${{ github.event.pull_request.head.ref }}
         with:
+          github-token: ${{ steps.get-token.outputs.app_token }}
           script: |
             if(context.payload.sender.id != context.payload.issue.user.id){
               const permission = await github.request(`GET /repos/${context.repo.owner}/${context.repo.repo}/collaborators/${context.payload.sender.login}/permission`, {
@@ -113,9 +151,3 @@ jobs:
               pull_number: context.issue.number,
               merge_method: 'rebase'
             });
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'merged'
-            })


### PR DESCRIPTION
GitHub Action Token not trigger other workflows
It is GitHub design to avoid infinity triggers loop.
See: https://github.com/ad-m/github-push-action/issues/32

Log: