### PR TITLE
feat: Run triggers workflow when PR reopened

### DIFF
--- a/workflow-templates/call-build-deb.yml
+++ b/workflow-templates/call-build-deb.yml
@@ -1,7 +1,6 @@
 name: Call build-deb
 on:
   pull_request_target:
-    types: [opened, synchronize]
     paths-ignore:
       - ".github/workflows/**"
 

--- a/workflow-templates/cppcheck.yml
+++ b/workflow-templates/cppcheck.yml
@@ -1,6 +1,8 @@
 name: cppcheck
 on:
   pull_request_target:
+    paths-ignore:
+      - ".github/workflows/**"
 
 concurrency:
   group: ${{ github.workflow }}-pull/${{ github.event.number }}


### PR DESCRIPTION
Does not limit the 'types' field of the pull_request_target

Log: