### PR TITLE
chore: add CI check and branch protection to dde repos

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -23,6 +23,22 @@ settings:
       - dde-control-center
       - dde-grand-search
       - deepin-screen-recorder
+      - dareader
+      - dde-daemon
+      - dde-session-shell
+      - dde-session-ui
+      - dde-wldpms
+      - dde-wloutput-daemon
+      - deepin-desktop-schemas
+      - deepin-network-proxy
+      - deepin-sound-theme
+      - default-settings
+      - dpa-ext-gnomekeyring
+      - go-dbus-factory
+      - go-gir-generator
+      - go-lib
+      - go-x11-client
+      - startdde
     features:
       issues:
         enable: false

--- a/repos/linuxdeepin/dareader.json
+++ b/repos/linuxdeepin/dareader.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/dareader/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/dareader/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/dareader/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/dareader/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/dareader/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/dde-daemon.json
+++ b/repos/linuxdeepin/dde-daemon.json
@@ -1,0 +1,22 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/dde-daemon/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/dde-daemon/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/dde-daemon/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/dde-daemon/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/dde-session-shell.json
+++ b/repos/linuxdeepin/dde-session-shell.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/dde-session-shell/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/dde-session-shell/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/dde-session-shell/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/dde-session-shell/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/dde-session-shell/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/dde-session-ui.json
+++ b/repos/linuxdeepin/dde-session-ui.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/dde-session-ui/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/dde-session-ui/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/dde-session-ui/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/dde-session-ui/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/dde-session-ui/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/dde-wldpms.json
+++ b/repos/linuxdeepin/dde-wldpms.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/dde-wldpms/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/dde-wldpms/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/dde-wldpms/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/dde-wldpms/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/dde-wldpms/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/dde-wloutput-daemon.json
+++ b/repos/linuxdeepin/dde-wloutput-daemon.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/dde-wloutput-daemon/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/dde-wloutput-daemon/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/dde-wloutput-daemon/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/dde-wloutput-daemon/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/dde-wloutput-daemon/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/deepin-desktop-schemas.json
+++ b/repos/linuxdeepin/deepin-desktop-schemas.json
@@ -1,0 +1,22 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-desktop-schemas/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-desktop-schemas/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-desktop-schemas/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-desktop-schemas/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/deepin-network-proxy.json
+++ b/repos/linuxdeepin/deepin-network-proxy.json
@@ -1,0 +1,22 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-network-proxy/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-network-proxy/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-network-proxy/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-network-proxy/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/deepin-sound-theme.json
+++ b/repos/linuxdeepin/deepin-sound-theme.json
@@ -1,0 +1,22 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-sound-theme/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-sound-theme/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-sound-theme/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-sound-theme/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/default-settings.json
+++ b/repos/linuxdeepin/default-settings.json
@@ -1,0 +1,22 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/default-settings/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/default-settings/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/default-settings/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/default-settings/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/dpa-ext-gnomekeyring.json
+++ b/repos/linuxdeepin/dpa-ext-gnomekeyring.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master", "dev/.+", "maintain/.+", "uos"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/dpa-ext-gnomekeyring/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+", "uos"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/dpa-ext-gnomekeyring/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+", "uos"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/dpa-ext-gnomekeyring/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+", "uos"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/dpa-ext-gnomekeyring/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+", "uos"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/dpa-ext-gnomekeyring/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/go-dbus-factory.json
+++ b/repos/linuxdeepin/go-dbus-factory.json
@@ -1,0 +1,22 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/go-dbus-factory/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/go-dbus-factory/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/go-dbus-factory/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/go-dbus-factory/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/go-gir-generator.json
+++ b/repos/linuxdeepin/go-gir-generator.json
@@ -1,0 +1,22 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/go-gir-generator/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/go-gir-generator/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/go-gir-generator/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/go-gir-generator/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/go-lib.json
+++ b/repos/linuxdeepin/go-lib.json
@@ -1,0 +1,22 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/go-lib/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/go-lib/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/go-lib/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/go-lib/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/go-x11-client.json
+++ b/repos/linuxdeepin/go-x11-client.json
@@ -1,0 +1,22 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/go-x11-client/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/go-x11-client/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/go-x11-client/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/go-x11-client/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/startdde.json
+++ b/repos/linuxdeepin/startdde.json
@@ -1,0 +1,22 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/startdde/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/startdde/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/startdde/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/startdde/.github/workflows/call-build-deb.yml"
+  }
+]


### PR DESCRIPTION
为 dde 相关项目设置分支保护和 CI 检查

@wubw1992 请关注：

- 此 PR 只包含了截至目前已迁移完成的项目
- 非 C++ 项目未设置 cppcheck 检查
- 分支保护仅保护 master，若项目在使用非 master 分支进行开发，请切换到 master
- 在合入前，部分项目若包含 `.github/workflows/build.yaml` ，则请删除此文件（此 CI 应该是跑不过的，合入后会因为此 CI 失败而影响合并）