### PR TITLE
chore: ab-recovery CI and branch config

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -54,6 +54,7 @@ settings:
       - dde-launcher
       - dde-qt-dbus-factory
       - lastore-daemon
+      - deepin-ab-recovery
     features:
       issues:
         enable: false

--- a/repos/linuxdeepin/deepin-ab-recovery.json
+++ b/repos/linuxdeepin/deepin-ab-recovery.json
@@ -1,0 +1,22 @@
+[
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-ab-recovery/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-ab-recovery/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-ab-recovery/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-ab-recovery/.github/workflows/call-build-deb.yml"
+  }
+]


### PR DESCRIPTION
ab-recovery 项目 CI 和分支保护

这个 PR 后，dde 相关的组件应该已经全部迁移完成了