### PR TITLE
fix: username does not exist

### DIFF
--- a/teams.yaml
+++ b/teams.yaml
@@ -81,7 +81,7 @@ teams:
       - caixr23
       - shaotianlu1995
       - rocet92
-      - weizhixiang1993
+      - weizhixiangcoder
       - 2722195064
     repositories_permissions:
       triage:


### PR DESCRIPTION
处理用户名不存在问题，对应的用户名已联系对应人员确认

错误的用户名由 https://github.com/linuxdeepin/.github/pull/120 引入

Log: 处理用户名不存在问题