### PR TITLE
fix: dtkcommon doesn't neet cppcheck

### DIFF
--- a/repos/linuxdeepin/dtkcommon.json
+++ b/repos/linuxdeepin/dtkcommon.json
@@ -16,11 +16,6 @@
   },
   {
     "branches": ["master"],
-    "src": "workflow-templates/cppcheck.yml",
-    "dest": "linuxdeepin/dtkcommon/.github/workflows/cppcheck.yml"
-  },
-  {
-    "branches": ["master"],
     "src": "workflow-templates/call-build-deb.yml",
     "dest": "linuxdeepin/dtkcommon/.github/workflows/call-build-deb.yml"
   }


### PR DESCRIPTION
dtkcommon 不需要 cppcheck 检查，检查肯定会失败（ https://github.com/linuxdeepin/dtkcommon/pull/7 ）

Log: dtkcommon 不需要 cppcheck 检查