### PR TITLE
chore: don't run yamllint on push

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,8 +1,6 @@
 name: Validate-YAML
 
 on:
-  push:
-    branches: [ master, main ]
   pull_request:
     types: [ opened, synchronize ]
 


### PR DESCRIPTION
合并后不需要跑 yamllint，只在 PR 检查就够了