### PR TITLE
chore: ci config and branch protection for game proj

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -71,6 +71,8 @@ settings:
       - deepin-cursor-theme
       - deepin-wallpapers
       - deepin-log-viewer
+      - deepin-gomoku
+      - deepin-lianliankan
     features:
       issues:
         enable: false

--- a/repos/linuxdeepin/deepin-gomoku.json
+++ b/repos/linuxdeepin/deepin-gomoku.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-gomoku/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-gomoku/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-gomoku/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/deepin-gomoku/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-gomoku/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/deepin-lianliankan.json
+++ b/repos/linuxdeepin/deepin-lianliankan.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-lianliankan/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-lianliankan/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-lianliankan/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/deepin-lianliankan/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-lianliankan/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/teams.yaml
+++ b/teams.yaml
@@ -399,7 +399,7 @@ teams:
         - deepin-calculator
   - name: deepin-gomoku
     parent_team: Maintainers
-    members: 
+    members:
       - guoshaoyu
       - lxp002764
     repositories_permissions:


### PR DESCRIPTION
为连连看和五子棋项目配置 CI 和分支保护

需等待连连看和五子棋项目就绪后再合入

Log: