### PR TITLE
chore: config for boot-maker and clone

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -70,6 +70,8 @@ settings:
       - deepin-icon-theme
       - deepin-cursor-theme
       - deepin-wallpapers
+      - deepin-clone
+      - deepin-boot-maker
       - deepin-log-viewer
     features:
       issues:

--- a/repos/linuxdeepin/deepin-boot-maker.json
+++ b/repos/linuxdeepin/deepin-boot-maker.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-boot-maker/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-boot-maker/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-boot-maker/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/deepin-boot-maker/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-boot-maker/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/deepin-clone.json
+++ b/repos/linuxdeepin/deepin-clone.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-clone/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-clone/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-clone/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/deepin-clone/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-clone/.github/workflows/call-build-deb.yml"
+  }
+]


### PR DESCRIPTION
deepin-boot-maker 和 deepin-clone 的分支保护和 CI 配置

需等待 boot-maker 就绪后再合入。

Log: