### PR TITLE
fix: deepin-gomoku currently using dev branch

### DIFF
--- a/repos/linuxdeepin/deepin-gomoku.json
+++ b/repos/linuxdeepin/deepin-gomoku.json
@@ -1,26 +1,26 @@
 [
   {
-    "branches": ["master", "dev/.+", "maintain/.+"],
+    "branches": ["master", "dev", "maintain/.+"],
     "src": "workflow-templates/backup-to-gitlab.yml",
     "dest": "linuxdeepin/deepin-gomoku/.github/workflows/backup-to-gitlab.yml"
   },
   {
-    "branches": ["master", "dev/.+", "maintain/.+"],
+    "branches": ["master", "dev", "maintain/.+"],
     "src": "workflow-templates/call-commitlint.yml",
     "dest": "linuxdeepin/deepin-gomoku/.github/workflows/call-commitlint.yml"
   },
   {
-    "branches": ["master", "dev/.+", "maintain/.+"],
+    "branches": ["master", "dev", "maintain/.+"],
     "src": "workflow-templates/call-chatOps.yml",
     "dest": "linuxdeepin/deepin-gomoku/.github/workflows/call-chatOps.yml"
   },
   {
-    "branches": ["master", "dev/.+", "maintain/.+"],
+    "branches": ["master", "dev", "maintain/.+"],
     "src": "workflow-templates/cppcheck.yml",
     "dest": "linuxdeepin/deepin-gomoku/.github/workflows/cppcheck.yml"
   },
   {
-    "branches": ["master", "dev/.+", "maintain/.+"],
+    "branches": ["master", "dev", "maintain/.+"],
     "src": "workflow-templates/call-build-deb.yml",
     "dest": "linuxdeepin/deepin-gomoku/.github/workflows/call-build-deb.yml"
   }


### PR DESCRIPTION
五子棋还在使用 dev 作为主线分支名称，所以修改配置

Log: