### PR TITLE
chore: CI and branch config for deepin-voice-note

### DIFF
--- a/repos/linuxdeepin/deepin-voice-note.json
+++ b/repos/linuxdeepin/deepin-voice-note.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-voice-note/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-voice-note/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-voice-note/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/deepin-voice-note/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-voice-note/.github/workflows/call-build-deb.yml"
+  }
+]


### PR DESCRIPTION
语音记事本的 CI 配置于分支保护