### PR TITLE
chore: CI and branch config for deepin-turbo

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -77,6 +77,8 @@ settings:
       - deepin-lianliankan
       - deepin-downloader
       - dde-app-services
+      - deepin-voice-note
+      - deepin-turbo
     features:
       issues:
         enable: false

--- a/repos/linuxdeepin/deepin-turbo.json
+++ b/repos/linuxdeepin/deepin-turbo.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-turbo/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-turbo/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-turbo/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/deepin-turbo/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-turbo/.github/workflows/call-build-deb.yml"
+  }
+]


### PR DESCRIPTION
deepin-turbo 的 CI 配置和分支保护，也补充了 voice note 的分支保护

注意：

- [x] 确认迁完了再合
- [x] deepin-turbo 仓库下有个旧的 /.github/workflows/build.yaml 文件需要删

其它事项：

- turbo 的 debian/control 声明的依赖应该需要改一下（[这里](https://github.com/linuxdeepin/deepin-turbo/blob/427439da4ba6daf87290a931c48a56cb1eba973d/debian/control#L13)）
- README 里的 maintainer...?