### PR TITLE
chore: add CI and branch protection for fcitxconfigtool-plugin

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -79,6 +79,7 @@ settings:
       - dde-app-services
       - deepin-voice-note
       - deepin-turbo
+      - deepin-fcitxconfigtool-plugin
     features:
       issues:
         enable: false

--- a/repos/linuxdeepin/deepin-fcitxconfigtool-plugin.json
+++ b/repos/linuxdeepin/deepin-fcitxconfigtool-plugin.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-fcitxconfigtool-plugin/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-fcitxconfigtool-plugin/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-fcitxconfigtool-plugin/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/deepin-fcitxconfigtool-plugin/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-fcitxconfigtool-plugin/.github/workflows/call-build-deb.yml"
+  }
+]


### PR DESCRIPTION
为 fcitx 配置工具插件配置 CI 和分支保护

需等待项目就绪后合入，检查项：

- [x] 相关维护人员已加入 linuxdeepin 组织
- [x] 研发主干最新代码已推送至 GitHub
- [x] 当前已（对社区）发布的 tag 已推送至 GitHub
- [x] 研发主线分支已确认（应为 master，若因为项目原因暂时无法切换至 master 则应先修改 GitHub 的默认分支为实际的研发主干分支）