### PR TITLE
chore: CI and branch config for deepin-diskmanager

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -78,6 +78,7 @@ settings:
       - deepin-downloader
       - dde-app-services
       - deepin-voice-note
+      - deepin-diskmanager
       - deepin-turbo
     features:
       issues:

--- a/repos/linuxdeepin/deepin-diskmanager.json
+++ b/repos/linuxdeepin/deepin-diskmanager.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-diskmanager/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-diskmanager/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-diskmanager/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/deepin-diskmanager/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-diskmanager/.github/workflows/call-build-deb.yml"
+  }
+]


### PR DESCRIPTION
磁盘管理器的 CI 配置与分支保护

需等待项目就绪后合入，检查项：

- [x] 相关维护人员已加入 linuxdeepin 组织
- [x] 研发主干最新代码已推送至 GitHub
- [x] 当前已（对社区）发布的 tag 已推送至 GitHub
- [x] 研发主线分支已确认（应为 master，若因为项目原因暂时无法切换至 master 则应先修改 GitHub 的默认分支为实际的研发主干分支）