### PR TITLE
chore: wloutput CI and branch config

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -29,6 +29,7 @@ settings:
       - dde-session-ui
       - dde-wldpms
       - dde-wloutput-daemon
+      - dde-wloutput
       - deepin-desktop-schemas
       - deepin-network-proxy
       - deepin-sound-theme

--- a/repos/linuxdeepin/dde-wloutput.json
+++ b/repos/linuxdeepin/dde-wloutput.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/dde-wloutput/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/dde-wloutput/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/dde-wloutput/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/dde-wloutput/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/dde-wloutput/.github/workflows/call-build-deb.yml"
+  }
+]


### PR DESCRIPTION
dde-wloutput 的分支保护和 CI 配置

需等待项目就绪后合入，检查项：

- [x] 相关维护人员已加入 linuxdeepin 组织
- [x] 研发主干最新代码已推送至 GitHub
- [x] 当前已（对社区）发布的 tag 已推送至 GitHub
- [x] 研发主线分支已确认（应为 master，若因为项目原因暂时无法切换至 master 则应先修改 GitHub 的默认分支为实际的研发主干分支）