### PR TITLE
fix: enable issue board for each repository

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -84,7 +84,7 @@ settings:
       - deepin-fcitxconfigtool-plugin
     features:
       issues:
-        enable: false
+        enable: true
       allow_merge_commit:
         enable: false
     branches:


### PR DESCRIPTION
现在在新建 issue 时，向导会导向 developer-center，所以可以开启 issue 面板了。