### PR TITLE
chore: CI and branch config for DFM related repos

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -82,6 +82,9 @@ settings:
       - deepin-diskmanager
       - deepin-turbo
       - deepin-fcitxconfigtool-plugin
+      - dde-device-formatter
+      - deepin-screensaver
+      - disomaster
     features:
       issues:
         enable: false

--- a/repos/linuxdeepin/dde-device-formatter.json
+++ b/repos/linuxdeepin/dde-device-formatter.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/dde-device-formatter/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/dde-device-formatter/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/dde-device-formatter/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/dde-device-formatter/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/dde-device-formatter/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/deepin-screensaver.json
+++ b/repos/linuxdeepin/deepin-screensaver.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-screensaver/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-screensaver/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-screensaver/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/deepin-screensaver/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-screensaver/.github/workflows/call-build-deb.yml"
+  }
+]

--- a/repos/linuxdeepin/disomaster.json
+++ b/repos/linuxdeepin/disomaster.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/disomaster/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/disomaster/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/disomaster/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/disomaster/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "develop/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/disomaster/.github/workflows/call-build-deb.yml"
+  }
+]


### PR DESCRIPTION
文件管理器项目组剩余项目的分支保护与 CI 配置

需等待项目就绪后合入，检查项：

- [x] 相关维护人员已加入 linuxdeepin 组织
- [x] 研发主干最新代码已推送至 GitHub
- [x] 当前已（对社区）发布的 tag 已推送至 GitHub
- [x] 研发主线分支已确认（应为 master，若因为项目原因暂时无法切换至 master 则应先修改 GitHub 的默认分支为实际的研发主干分支）