### PR TITLE
chore: remove mirror sync for deepin-manual

### DIFF
--- a/repos/linuxdeepin/deepin-manual.json
+++ b/repos/linuxdeepin/deepin-manual.json
@@ -1,11 +1,6 @@
 [
   {
     "branches": ["master", "dev/.+", "maintain/.+", "uos"],
-    "src": "workflow-templates/backup-to-gitlab.yml",
-    "dest": "linuxdeepin/deepin-manual/.github/workflows/backup-to-gitlab.yml"
-  },
-  {
-    "branches": ["master", "dev/.+", "maintain/.+", "uos"],
     "src": "workflow-templates/call-commitlint.yml",
     "dest": "linuxdeepin/deepin-manual/.github/workflows/call-commitlint.yml"
   },


### PR DESCRIPTION
仓库太大，比较耗 gitee 容量，暂时只备份到 gitlab

Log: