### PR TITLE
chore: CI and branch protection for dde-calendar

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -88,6 +88,7 @@ settings:
       - docparser
       - dde-printer
       - deepin-graphics-driver-manager
+      - dde-calendar
     features:
       issues:
         enable: true

--- a/repos/linuxdeepin/dde-calendar.json
+++ b/repos/linuxdeepin/dde-calendar.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/dde-calendar/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/dde-calendar/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/dde-calendar/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/dde-calendar/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/dde-calendar/.github/workflows/call-build-deb.yml"
+  }
+]


### PR DESCRIPTION
日历的分支保护与 CI 配置

需等待项目就绪后合入，检查项：

- [ ] Gerrit 对应项目的研发主线分支已设为只读
- [x] 相关维护人员已加入 linuxdeepin 组织
- [x] 研发主干最新代码已推送至 GitHub
- [x] 当前已（对社区）发布的 tag 已推送至 GitHub
- [x] 研发主线分支已确认（应为 master，若因为项目原因暂时无法切换至 master 则应先修改 GitHub 的默认分支为实际的研发主干分支）