### PR TITLE
fix: when merged re call build

### DIFF
--- a/workflow-templates/call-build-deb.yml
+++ b/workflow-templates/call-build-deb.yml
@@ -4,12 +4,17 @@ on:
     paths-ignore:
       - ".github/workflows/**"
 
+  pull_request:
+    types:
+      - closed
+
 concurrency:
   group: ${{ github.workflow }}-pull/${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:
   check_job:
+    if: ${{ github.event_name == 'pull_request_target' || github.event.pull_request.merged }}
     uses: linuxdeepin/.github/.github/workflows/build-deb.yml@master
     secrets:
       BridgeToken: ${{ secrets.BridgeToken }}


### PR DESCRIPTION
when merged re call build, use new github event name

Log: when merged re call build
