### PR TITLE
chore: CI and branch config for reader and devicemanager

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -90,6 +90,8 @@ settings:
       - dde-printer
       - deepin-graphics-driver-manager
       - dde-calendar
+      - deepin-reader
+      - deepin-devicemanager
     features:
       issues:
         enable: true

--- a/repos/linuxdeepin/deepin-devicemanager.json
+++ b/repos/linuxdeepin/deepin-devicemanager.json
@@ -1,0 +1,32 @@
+[
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-devicemanager/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-devicemanager/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-devicemanager/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/deepin-devicemanager/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-devicemanager/.github/workflows/call-build-deb.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-clacheck.yml",
+    "dest": "linuxdeepin/deepin-devicemanager/.github/workflows/call-clacheck.yml"
+  }
+]

--- a/repos/linuxdeepin/deepin-reader.json
+++ b/repos/linuxdeepin/deepin-reader.json
@@ -1,0 +1,32 @@
+[
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-reader/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-reader/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-reader/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/deepin-reader/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-reader/.github/workflows/call-build-deb.yml"
+  },
+  {
+    "branches": ["master", "develop/.+", "maintain/.+"],
+    "src": "workflow-templates/call-clacheck.yml",
+    "dest": "linuxdeepin/deepin-reader/.github/workflows/call-clacheck.yml"
+  }
+]


### PR DESCRIPTION
阅读器和设备管理器的 CI 与分支保护配置

需等待项目就绪后合入，检查项：

- [x] Gerrit 对应项目的研发主线分支已设为只读
- [x] 相关维护人员已加入 linuxdeepin 组织
- [x] 研发主干最新代码已推送至 GitHub
- [x] 当前已（对社区）发布的 tag 已推送至 GitHub
- [x] 研发主线分支已确认（应为 master，若因为项目原因暂时无法切换至 master 则应先修改 GitHub 的默认分支为实际的研发主干分支）