### PR TITLE
chore: CI and branch config for deepin-editor

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -92,6 +92,7 @@ settings:
       - dde-calendar
       - deepin-reader
       - deepin-devicemanager
+      - deepin-editor
     features:
       issues:
         enable: true

--- a/repos/linuxdeepin/deepin-editor.json
+++ b/repos/linuxdeepin/deepin-editor.json
@@ -1,0 +1,32 @@
+[
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-editor/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-editor/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-editor/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/deepin-editor/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-editor/.github/workflows/call-build-deb.yml"
+  },
+  {
+    "branches": ["master", "dev/.+", "maintain/.+"],
+    "src": "workflow-templates/call-clacheck.yml",
+    "dest": "linuxdeepin/deepin-editor/.github/workflows/call-clacheck.yml"
+  }
+]


### PR DESCRIPTION
编辑器项目 CI 和分支保护配置

需等待项目就绪后合入，检查项：

- [ ] Gerrit 对应项目的研发主线分支已设为只读
- [ ] 相关维护人员已加入 linuxdeepin 组织
- [ ] 研发主干最新代码已推送至 GitHub
- [ ] 当前已（对社区）发布的 tag 已推送至 GitHub
- [ ] 研发主线分支已确认（应为 master，若因为项目原因暂时无法切换至 master 则应先修改 GitHub 的默认分支为实际的研发主干分支）