### PR TITLE
chore: use the new conventional commit checker

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,15 +9,7 @@ jobs:
       - name: Fetch code
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Download commitlint config teamplate
-        run: |
-          wget https://raw.githubusercontent.com/linuxdeepin/.github/master/commitlint/commitlint.config.js \
-            -O ./commitlint.config.js
-
-      - name: CommitLint
-        uses: wagoid/commitlint-github-action@v4
-        with:
-          configFile: "./commitlint.config.js"
+      - name: Call Conventional Commits Checker
+        uses: linuxdeepin/action-conventionalcommits-checker@master


### PR DESCRIPTION
使用新的 commit 检查工作流，以解决 [commit 信息 body 中包含 `#` 会导致检查失败的情况](https://github.com/linuxdeepin/developer-center/issues/3122)。

测试：

- Action https://github.com/peeweep-test/.github/blob/main/.github/workflows/commitcheck.yml
- PR（失败时）：https://github.com/peeweep-test/.github/pull/17
- PR（成功时）：https://github.com/peeweep-test/.github/pull/19

Resolve https://github.com/linuxdeepin/developer-center/issues/3122