### PR TITLE
fix: error send license instead of doc check

### DIFF
--- a/repos/linuxdeepin/dtkwidget.json
+++ b/repos/linuxdeepin/dtkwidget.json
@@ -59,7 +59,7 @@
     "branches": [
       "master"
     ],
-    "src": "workflow-templates/call-license-check.yml",
+    "src": "workflow-templates/call-doc-check.yml",
     "dest": "linuxdeepin/dtkwidget/.github/workflows/call-doc-check.yml"
   }
 ]


### PR DESCRIPTION
fix send lincense to dtkwidget instead of doc chekc

Log: error send license check