### PR TITLE
fix: use new commitlint, use the old one as fallback

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -12,12 +12,19 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: Call Conventional Commits Checker
+        uses: linuxdeepin/action-conventionalcommits-checker@master
+        id: conventionalcommits-checker
+        continue-on-error: true
+
       - name: Download commitlint config teamplate
+        if: steps.conventionalcommits-checker.outcome == 'failure'
         run: |
           wget https://raw.githubusercontent.com/linuxdeepin/.github/master/commitlint/commitlint.config.js \
             -O ./commitlint.config.js
 
       - name: CommitLint
         uses: wagoid/commitlint-github-action@v4
+        if: steps.conventionalcommits-checker.outcome == 'failure'
         with:
           configFile: "./commitlint.config.js"


### PR DESCRIPTION
新的需要一些测试情况来了解失败的原因，此处允许新的检查失败，并在其失败时回退到旧的检查。

相关：https://github.com/linuxdeepin/.github/pull/286 https://github.com/linuxdeepin/developer-center/issues/3122
