### PR TITLE
chore: remove commitlint fallback

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -14,17 +14,3 @@ jobs:
 
       - name: Call Conventional Commits Checker
         uses: linuxdeepin/action-conventionalcommits-checker@master
-        id: conventionalcommits-checker
-        continue-on-error: true
-
-      - name: Download commitlint config teamplate
-        if: steps.conventionalcommits-checker.outcome == 'failure'
-        run: |
-          wget https://raw.githubusercontent.com/linuxdeepin/.github/master/commitlint/commitlint.config.js \
-            -O ./commitlint.config.js
-
-      - name: CommitLint
-        uses: wagoid/commitlint-github-action@v4
-        if: steps.conventionalcommits-checker.outcome == 'failure'
-        with:
-          configFile: "./commitlint.config.js"


### PR DESCRIPTION
已确认新的 commitlint 可正常进行检查，不再需要 fallback。

相关：https://github.com/linuxdeepin/.github/pull/291 https://github.com/linuxdeepin/.github/pull/286 https://github.com/linuxdeepin/developer-center/issues/3122