### PR TITLE
chore: remove cppcheck from deepin-desktop-base

### DIFF
--- a/repos/linuxdeepin/deepin-desktop-base.json
+++ b/repos/linuxdeepin/deepin-desktop-base.json
@@ -24,13 +24,6 @@
     "branches": [
       "apricot"
     ],
-    "src": "workflow-templates/cppcheck.yml",
-    "dest": "linuxdeepin/deepin-desktop-base/.github/workflows/cppcheck.yml"
-  },
-  {
-    "branches": [
-      "apricot"
-    ],
     "src": "workflow-templates/call-build-deb.yml",
     "dest": "linuxdeepin/deepin-desktop-base/.github/workflows/call-build-deb.yml"
   },


### PR DESCRIPTION
desktop-base 不是 c++ 项目，不需要相关检查
