### PR TITLE
fix: remove xyruos from deepin-kwin maintainers

### DIFF
--- a/teams.yaml
+++ b/teams.yaml
@@ -531,7 +531,6 @@ teams:
       - axylp
       - hitong602
       - ChaojiangLuo
-      - xyruos
     repositories_permissions:
       push:
         - deepin-kwin


### PR DESCRIPTION
remove xyruos from maintainers

Log: remove xyruos from deepin-kwin maintainers