### PR TITLE
chore: remove cppcheck from deepin-icon-theme

### DIFF
--- a/repos/linuxdeepin/deepin-icon-theme.json
+++ b/repos/linuxdeepin/deepin-icon-theme.json
@@ -24,13 +24,6 @@
     "branches": [
       "master"
     ],
-    "src": "workflow-templates/cppcheck.yml",
-    "dest": "linuxdeepin/deepin-icon-theme/.github/workflows/cppcheck.yml"
-  },
-  {
-    "branches": [
-      "master"
-    ],
     "src": "workflow-templates/call-build-deb.yml",
     "dest": "linuxdeepin/deepin-icon-theme/.github/workflows/call-build-deb.yml"
   },


### PR DESCRIPTION
图标主题不是 c++ 项目，不需要 cppcheck
