### PR TITLE
chore: CI and branch config for deepin-kwayland

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -53,6 +53,7 @@ settings:
       - deepin-pw-check
       - dde-kwin
       - deepin-kwin
+      - deepin-kwayland
       - dde-api
       - dde-launcher
       - dde-qt-dbus-factory

--- a/repos/linuxdeepin/deepin-kwayland.json
+++ b/repos/linuxdeepin/deepin-kwayland.json
@@ -1,0 +1,65 @@
+[
+  {
+    "branches": [
+      "master",
+      "maintain/.+"
+    ],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-kwayland/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "maintain/.+"
+    ],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-kwayland/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "maintain/.+"
+    ],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-kwayland/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "maintain/.+"
+    ],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/deepin-kwayland/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "maintain/.+"
+    ],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-kwayland/.github/workflows/call-build-deb.yml"
+  },
+  {
+    "branches": [
+      "master"
+    ],
+    "src": "workflow-templates/call-build-distribution.yml",
+    "dest": "linuxdeepin/deepin-kwayland/.github/workflows/call-build-distribution.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "maintain/.+"
+    ],
+    "src": "workflow-templates/call-clacheck.yml",
+    "dest": "linuxdeepin/deepin-kwayland/.github/workflows/call-clacheck.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "maintain/.+"
+    ],
+    "src": "workflow-templates/call-license-check.yml",
+    "dest": "linuxdeepin/deepin-kwayland/.github/workflows/call-license-check.yml"
+  }
+]


### PR DESCRIPTION
为 deepin-kwayland 配置分支保护与 CI

需等待项目就绪后合入，检查项：

- [x] 相关维护人员已加入 linuxdeepin 组织
- [x] 研发主干最新代码已推送至 GitHub
- [x] 当前已（对社区）发布的 tag 已推送至 GitHub
- [x] 研发主线分支已确认（应为 master，若因为项目原因暂时无法切换至 master 则应先修改 GitHub 的默认分支为实际的研发主干分支）