### PR TITLE
chore: override global issue template for DTK

### DIFF
--- a/issue-templates/config-empty.yml
+++ b/issue-templates/config-empty.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/repos/linuxdeepin/dtkaudiomanager.json
+++ b/repos/linuxdeepin/dtkaudiomanager.json
@@ -68,5 +68,12 @@
     ],
     "src": "workflow-templates/call-tag-build.yml",
     "dest": "linuxdeepin/dtkaudiomanager/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "issue-templates/config-empty.yml",
+    "dest": "linuxdeepin/dtkaudiomanager/.github/ISSUE_TEMPLATE/config.yml"
   }
 ]

--- a/repos/linuxdeepin/dtkbluetooth.json
+++ b/repos/linuxdeepin/dtkbluetooth.json
@@ -68,5 +68,12 @@
     ],
     "src": "workflow-templates/call-tag-build.yml",
     "dest": "linuxdeepin/dtkbluetooth/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "issue-templates/config-empty.yml",
+    "dest": "linuxdeepin/dtkbluetooth/.github/ISSUE_TEMPLATE/config.yml"
   }
 ]

--- a/repos/linuxdeepin/dtkcore.json
+++ b/repos/linuxdeepin/dtkcore.json
@@ -75,5 +75,12 @@
     ],
     "src": "workflow-templates/call-tag-build.yml",
     "dest": "linuxdeepin/dtkcore/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "issue-templates/config-empty.yml",
+    "dest": "linuxdeepin/dtkcore/.github/ISSUE_TEMPLATE/config.yml"
   }
 ]

--- a/repos/linuxdeepin/dtkcrypt.json
+++ b/repos/linuxdeepin/dtkcrypt.json
@@ -68,5 +68,12 @@
     ],
     "src": "workflow-templates/call-tag-build.yml",
     "dest": "linuxdeepin/dtkcrypt/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "issue-templates/config-empty.yml",
+    "dest": "linuxdeepin/dtkcrypt/.github/ISSUE_TEMPLATE/config.yml"
   }
 ]

--- a/repos/linuxdeepin/dtkdeclarative.json
+++ b/repos/linuxdeepin/dtkdeclarative.json
@@ -75,5 +75,12 @@
     ],
     "src": "workflow-templates/call-tag-build.yml",
     "dest": "linuxdeepin/dtkdeclarative/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "issue-templates/config-empty.yml",
+    "dest": "linuxdeepin/dtkdeclarative/.github/ISSUE_TEMPLATE/config.yml"
   }
 ]

--- a/repos/linuxdeepin/dtkdevice.json
+++ b/repos/linuxdeepin/dtkdevice.json
@@ -68,5 +68,12 @@
     ],
     "src": "workflow-templates/call-tag-build.yml",
     "dest": "linuxdeepin/dtkdevice/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "issue-templates/config-empty.yml",
+    "dest": "linuxdeepin/dtkdevice/.github/ISSUE_TEMPLATE/config.yml"
   }
 ]

--- a/repos/linuxdeepin/dtkdisplay.json
+++ b/repos/linuxdeepin/dtkdisplay.json
@@ -68,5 +68,12 @@
     ],
     "src": "workflow-templates/call-tag-build.yml",
     "dest": "linuxdeepin/dtkdisplay/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "issue-templates/config-empty.yml",
+    "dest": "linuxdeepin/dtkdisplay/.github/ISSUE_TEMPLATE/config.yml"
   }
 ]

--- a/repos/linuxdeepin/dtkgui.json
+++ b/repos/linuxdeepin/dtkgui.json
@@ -75,5 +75,12 @@
     ],
     "src": "workflow-templates/call-tag-build.yml",
     "dest": "linuxdeepin/dtkgui/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "issue-templates/config-empty.yml",
+    "dest": "linuxdeepin/dtkgui/.github/ISSUE_TEMPLATE/config.yml"
   }
 ]

--- a/repos/linuxdeepin/dtkio.json
+++ b/repos/linuxdeepin/dtkio.json
@@ -68,5 +68,12 @@
     ],
     "src": "workflow-templates/call-tag-build.yml",
     "dest": "linuxdeepin/dtkio/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "issue-templates/config-empty.yml",
+    "dest": "linuxdeepin/dtkio/.github/ISSUE_TEMPLATE/config.yml"
   }
 ]

--- a/repos/linuxdeepin/dtkmultimedia.json
+++ b/repos/linuxdeepin/dtkmultimedia.json
@@ -68,5 +68,12 @@
     ],
     "src": "workflow-templates/call-tag-build.yml",
     "dest": "linuxdeepin/dtkmultimedia/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "issue-templates/config-empty.yml",
+    "dest": "linuxdeepin/dtkmultimedia/.github/ISSUE_TEMPLATE/config.yml"
   }
 ]

--- a/repos/linuxdeepin/dtknetworkmanager.json
+++ b/repos/linuxdeepin/dtknetworkmanager.json
@@ -68,5 +68,12 @@
     ],
     "src": "workflow-templates/call-tag-build.yml",
     "dest": "linuxdeepin/dtknetworkmanager/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "issue-templates/config-empty.yml",
+    "dest": "linuxdeepin/dtknetworkmanager/.github/ISSUE_TEMPLATE/config.yml"
   }
 ]

--- a/repos/linuxdeepin/dtksystem.json
+++ b/repos/linuxdeepin/dtksystem.json
@@ -68,5 +68,12 @@
     ],
     "src": "workflow-templates/call-tag-build.yml",
     "dest": "linuxdeepin/dtksystem/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "issue-templates/config-empty.yml",
+    "dest": "linuxdeepin/dtksystem/.github/ISSUE_TEMPLATE/config.yml"
   }
 ]

--- a/repos/linuxdeepin/dtksystemsettings.json
+++ b/repos/linuxdeepin/dtksystemsettings.json
@@ -68,5 +68,12 @@
     ],
     "src": "workflow-templates/call-tag-build.yml",
     "dest": "linuxdeepin/dtksystemsettings/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "issue-templates/config-empty.yml",
+    "dest": "linuxdeepin/dtksystemsettings/.github/ISSUE_TEMPLATE/config.yml"
   }
 ]

--- a/repos/linuxdeepin/dtkwidget.json
+++ b/repos/linuxdeepin/dtkwidget.json
@@ -75,5 +75,12 @@
     ],
     "src": "workflow-templates/call-tag-build.yml",
     "dest": "linuxdeepin/dtkwidget/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "issue-templates/config-empty.yml",
+    "dest": "linuxdeepin/dtkwidget/.github/ISSUE_TEMPLATE/config.yml"
   }
 ]


### PR DESCRIPTION
为 DTK 移除全局的 issue 模板，使用一个空白模板（和普通的完全没配置的情况效果一致，可在[这里](https://github.com/peeweep-test/test/issues)预览效果 ）。

cc @groveer