### PR TITLE
chore: add CI configuration for unilang repo

### DIFF
--- a/repos/linuxdeepin/unilang.json
+++ b/repos/linuxdeepin/unilang.json
@@ -1,0 +1,29 @@
+[
+  {
+    "branches": [
+      "master",
+      "dev/.+",
+      "maintain/.+"
+    ],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/unilang/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "dev/.+",
+      "maintain/.+"
+    ],
+    "src": "workflow-templates/call-clacheck.yml",
+    "dest": "linuxdeepin/unilang/.github/workflows/call-clacheck.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "dev/.+",
+      "maintain/.+"
+    ],
+    "src": "workflow-templates/call-license-check.yml",
+    "dest": "linuxdeepin/unilang/.github/workflows/call-license-check.yml"
+  }
+]


### PR DESCRIPTION
为 Unilang 添加基础的 CI 配置：

1. 镜像仓库备份
2. CLA 签署检查
3. 许可协议合规检查

本次未对下述 CI 进行配置：

1. [Commit 提交信息规范](https://www.conventionalcommits.org/zh-hans/v1.0.0/)检查
2. 自动打包检查
3. 自动打 Tag 支持
4. 合并机器人（`/merge` ，`/check` 等命令支持）

cc @FrankHB 