### PR TITLE
chore: also allow README.zh-CN.md

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -41,7 +41,7 @@ jobs:
       - name: README.zh_CN.md Check
         id: zhrcheck
         continue-on-error: true
-        run: if [ ! -f "README.zh_CN.md" ]; then echo "missing README.zh_CN.md";return 1;fi
+        run: if [ ! -f "README.zh_CN.md" -a ! -f "README.zh-CN.md" ]; then echo "missing README.zh_CN.md";return 1;fi
         shell: zsh {0}
       - name: Generate README zh_CN Check Reports
         if: steps.zhrcheck.outcome != 'success'


### PR DESCRIPTION
鉴于 gitea（1.18 起）和 gitee 都支持 README.zh-CN.md 的写法，此处也放宽限制，允许 .zh-CN.md 表示中文版本。