### PR TITLE
chore: add CI config for deepin-spec repo

### DIFF
--- a/repos/linuxdeepin/deepin-specifications.json
+++ b/repos/linuxdeepin/deepin-specifications.json
@@ -1,0 +1,27 @@
+[
+  {
+    "branches": [
+      "master",
+      "dev/.+",
+      "maintain/.+"
+    ],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-specifications/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "dev/.+",
+      "maintain/.+"
+    ],
+    "src": "workflow-templates/call-clacheck.yml",
+    "dest": "linuxdeepin/deepin-specifications/.github/workflows/call-clacheck.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "issue-templates/config-empty.yml",
+    "dest": "linuxdeepin/deepin-specifications/.github/ISSUE_TEMPLATE/config.yml"
+  }
+]


### PR DESCRIPTION
为 deepin-specifications 仓库配置 CI。

注：仅配置了备份 / CLA 检查以及覆盖全局 issue 模板的配置。