### PR TITLE
feat: online development doc generation support

### DIFF
--- a/.github/workflows/call-deploy-dev-doc.yml
+++ b/.github/workflows/call-deploy-dev-doc.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploydocs:
+    uses: linuxdeepin/.github/.github/workflows/deploy-dev-doc.yml@master

--- a/.github/workflows/deploy-dev-doc.yml
+++ b/.github/workflows/deploy-dev-doc.yml
@@ -1,0 +1,60 @@
+name: deploy doc to gh-pages
+
+on:
+  workflow_call:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    container:
+      image: linuxdeepin/apricot:latest
+      options: --privileged
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup
+        - /etc/machine-id:/etc/machine-id
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: init base environment
+        run: |
+          echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+          rm /etc/apt/sources.list
+          echo "deb [trusted=yes] https://deepin-community.github.io/deepin-dde-repo apricot main\ndeb-src [trusted=yes] https://deepin-community.github.io/deepin-dde-repo apricot main" >> /etc/apt/sources.list
+          echo "deb [trusted=yes] https://deepin-community.github.io/deepin-dde-deps-repo apricot main\ndeb-src [trusted=yes] https://deepin-community.github.io/deepin-dde-deps-repo apricot main" >> /etc/apt/sources.list
+          echo "deb [trusted=yes] https://ftp.jaist.ac.jp/pub/Linux/deepin/ apricot main contrib non-free\ndeb-src [trusted=yes] https://ftp.jaist.ac.jp/pub/Linux/deepin/ apricot main contrib non-free" >> /etc/apt/sources.list
+          apt-get update && apt-get install -y --force-yes ca-certificates apt-transport-https sudo
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - name: Prepare
+        run: |
+          sudo apt-get install -y --force-yes doxygen
+          sudo apt-get install -y --force-yes devscripts equivs git
+          mk-build-deps
+          sudo apt-get install -y --force-yes ./*.deb
+          git clone https://github.com/jothepro/doxygen-awesome-css.git --depth=1
+      - name: Build Docs
+        run: |
+          cmake -Bbuild -DBUILD_DOCS=ON -DBUILD_TESTING=OFF -DDOXYGEN_GENERATE_HTML="YES" \
+                        -DDOXYGEN_HTML_EXTRA_STYLESHEET="`pwd`/doxygen-awesome-css/doxygen-awesome.css" \
+                        -DDOXYGEN_TAGFILES="qtcore.tags=http://doc.qt.io/qt-5/;qtwidgets/tags=http://doc.qt.io/qt-5/" .
+          cmake --build build --target doxygen
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./build/docs/html
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/repos/linuxdeepin/dtkcore.json
+++ b/repos/linuxdeepin/dtkcore.json
@@ -80,6 +80,13 @@
     "branch": [
       "master"
     ],
+    "src": "workflow-templates/call-deploy-dev-doc.yml",
+    "dest": "linuxdeepin/dtkcore/.github/workflows/call-deploy-dev-doc.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
     "src": "issue-templates/empty-issue.md",
     "dest": "linuxdeepin/dtkcore/.github/ISSUE_TEMPLATE/empty-issue.md"
   },

--- a/repos/linuxdeepin/dtkdeclarative.json
+++ b/repos/linuxdeepin/dtkdeclarative.json
@@ -80,6 +80,13 @@
     "branch": [
       "master"
     ],
+    "src": "workflow-templates/call-deploy-dev-doc.yml",
+    "dest": "linuxdeepin/dtkdeclarative/.github/workflows/call-deploy-dev-doc.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
     "src": "issue-templates/empty-issue.md",
     "dest": "linuxdeepin/dtkdeclarative/.github/ISSUE_TEMPLATE/empty-issue.md"
   },

--- a/repos/linuxdeepin/dtkgui.json
+++ b/repos/linuxdeepin/dtkgui.json
@@ -80,6 +80,13 @@
     "branch": [
       "master"
     ],
+    "src": "workflow-templates/call-deploy-dev-doc.yml",
+    "dest": "linuxdeepin/dtkgui/.github/workflows/call-deploy-dev-doc.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
     "src": "issue-templates/empty-issue.md",
     "dest": "linuxdeepin/dtkgui/.github/ISSUE_TEMPLATE/empty-issue.md"
   },

--- a/repos/linuxdeepin/dtkwidget.json
+++ b/repos/linuxdeepin/dtkwidget.json
@@ -80,6 +80,13 @@
     "branch": [
       "master"
     ],
+    "src": "workflow-templates/call-deploy-dev-doc.yml",
+    "dest": "linuxdeepin/dtkwidget/.github/workflows/call-deploy-dev-doc.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
     "src": "issue-templates/empty-issue.md",
     "dest": "linuxdeepin/dtkwidget/.github/ISSUE_TEMPLATE/empty-issue.md"
   },


### PR DESCRIPTION
添加在线开发文档生成的支持，并为 DTK 核心组件添加相应的配置。

注：

部署此工作流的项目 *必须* 遵循文档规范，具体而言需要满足下述要求：

1. 文档 **必须** 通过 cmake 名为 `doxygen` 的自定义目标进行生成
2. 生成的文档 **必须** 位于项目生成目录下的 `docs/` 子目录下，其中，网页版文档位于 `docs/html/` 子目录下
3. 文档 **必须** 能够接受通过定义 `DOXYGEN_HTML_EXTRA_STYLESHEET` 的方式指定样式表
4. 部署合入前，需要联系仓库管理员开启仓库的 GitHub Pages 支持并设置为 Action（此 PR 涉及到的项目均已设置完毕，其它项目配置前联系我即可，或也可在 [deepin-devel](https://www.freelists.org/archive/deepin-devel/) 邮件列表申请）

cc @tsic404 @xzl01 