### PR TITLE
fix: open build-deb for deepin-deb-installer

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # disable uos
-    if: false
+    if: ${{ github.repository == 'linuxdeepin/deepin-deb-installer' }}
     steps:
       - name: Print Environment
         run: export


### PR DESCRIPTION
deepin-deb-installer need build on v23 for intergration

log: