### PR TITLE
fix: allow build-deb

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -14,8 +14,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # disable uos
-    if: ${{ github.repository == 'linuxdeepin/deepin-deb-installer' }}
     steps:
       - name: Print Environment
         run: export


### PR DESCRIPTION
build-deb scripts has disabled all uos build,
only deepin-related builds are enabled

log: