### PR TITLE
chore: add CI for ocr-plugin-manager project

### DIFF
--- a/repos/linuxdeepin/deepin-ocr-plugin-manager.json
+++ b/repos/linuxdeepin/deepin-ocr-plugin-manager.json
@@ -1,0 +1,80 @@
+[
+  {
+    "branches": [
+      "master",
+      "release/.+"
+    ],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/deepin-ocr-plugin-manager/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "release/.+"
+    ],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/deepin-ocr-plugin-manager/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "release/.+"
+    ],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/deepin-ocr-plugin-manager/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "release/.+"
+    ],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/deepin-ocr-plugin-manager/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "release/.+"
+    ],
+    "src": "workflow-templates/call-build-deb.yml",
+    "dest": "linuxdeepin/deepin-ocr-plugin-manager/.github/workflows/call-build-deb.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "release/.+"
+    ],
+    "src": "workflow-templates/call-clacheck.yml",
+    "dest": "linuxdeepin/deepin-ocr-plugin-manager/.github/workflows/call-clacheck.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "release/.+"
+    ],
+    "src": "workflow-templates/call-license-check.yml",
+    "dest": "linuxdeepin/deepin-ocr-plugin-manager/.github/workflows/call-license-check.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "release/.+"
+    ],
+    "src": "workflow-templates/call-build-distribution.yml",
+    "dest": "linuxdeepin/deepin-ocr-plugin-manager/.github/workflows/call-build-distribution.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-auto-tag.yml",
+    "dest": "linuxdeepin/deepin-ocr-plugin-manager/.github/workflows/call-auto-tag.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-tag-build.yml",
+    "dest": "linuxdeepin/deepin-ocr-plugin-manager/.github/workflows/call-tag-build.yml"
+  }
+]


### PR DESCRIPTION
为 ocr 插件管理器添加 CI 配置。
暂未添加分支保护，因为检查现在肯定过不去。

cc @starhcq 