### PR TITLE
chore: archive dtkdisplay

### DIFF
--- a/organization.yaml
+++ b/organization.yaml
@@ -109,7 +109,6 @@ settings:
       - dtksystemsettings
       - dtknotifications
       - dtkdevice
-      - dtkdisplay
       - dtknetwork
       - dtkbluetooth
       - dtkcrypt

--- a/teams.yaml
+++ b/teams.yaml
@@ -425,7 +425,6 @@ teams:
         - dtk-template
         - dtksystemsettings
         - dtkdevice
-        - dtkdisplay
         - dtkbluetooth
         - dtkcrypt
         - dtkio


### PR DESCRIPTION
dtkdisplay has been ported to gerrit, we don't need it on github anymore.

Log: archive dtkdisplay