### PR TITLE
chore: add push permission to fcitx for dde

### DIFF
--- a/teams.yaml
+++ b/teams.yaml
@@ -66,6 +66,8 @@ teams:
         - dde-api-proxy
         - dde-widgets
         - deepin-desktop-theme
+        - deepin-fcitxconfigtool-plugin
+        - deepin-fcitx5configtool-plugin
   - name: deepin
     members:
       - felixonmars


### PR DESCRIPTION
deepin-fcitx5configtool-plugin and deepin-fcitxconfigtool-plugin now are maintained by zsien who is in dde team.

Log: add push permission to fcitx for dde