### PR TITLE
feat: Add dde-calendar to deepin-home team

### DIFF
--- a/teams.yaml
+++ b/teams.yaml
@@ -664,6 +664,7 @@ teams:
     repositories_permissions:
       push:
         - deepin-home
+        - dde-calendar
   # Corporate Contributor: Phytium
   - name: corporate-contributor-phytium
     parent_team: Maintainers


### PR DESCRIPTION
给日历项目的维护人员添加写权限

Log: