### PR TITLE
chore(CI): cancel jenkins build

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   build:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Print Environment


### PR DESCRIPTION
可以根据需要开启obs构建,开启方法为仓库添加.obs/workflows.yml,文件例子:https://github.com/deepin-community/template-repository/blob/master/.obs/workflows.yml