### PR TITLE
fix: typo in the workflow of delopy-dev-doc

### DIFF
--- a/.github/workflows/deploy-dev-doc.yml
+++ b/.github/workflows/deploy-dev-doc.yml
@@ -109,8 +109,8 @@ jobs:
           ssh-keygen -y -f ~/.ssh/id_rsa
           git config --global user.name deepin-admin-bot
           git config --global user.email deepin-admin-bot@deepin.org
-          git clone git@codeberg.org:linuxdeepin/dtkcore.git
-          cd dtkcore
+          git clone git@codeberg.org:${{ github.event.repository.name }}.git codeberg_repo
+          cd codeberg_repo
           git branch -D $DOCS_BRANCH || true
           git checkout --orphan $DOCS_BRANCH
           git rm -rf .


### PR DESCRIPTION
部署文档的工作流存在错别字,导致文档无法被正确推送

Log: