### PR TITLE
chore(CI): use pr title as integration message

### DIFF
--- a/.github/workflows/auto-integration-pr.yml
+++ b/.github/workflows/auto-integration-pr.yml
@@ -149,7 +149,8 @@ jobs:
             const fs = require('fs')
 
             integrationContent = yaml.load(fs.readFileSync('integration.yml'), 'utf8')
-            integrationContent.message = "Integrated for " + milestone
+            // use pull request title as integration title
+            integrationContent.message = "${{ github.event.pull_request.title }} by @${{ github.event.pull_request.user.login }}"
             integrationContent.milestone = milestone
             if (topic != "undefined") {
               integrationContent.topic = topic


### PR DESCRIPTION
/cc @myml @babyfengfjx @Zeno-sole @BLumia 

pr中使用`/integrate`命令提交集成的方式会默认直接使用pr的title作为集成单的title，并包含pr提交者的github名称。