### PR TITLE
CI: add CI configuration for dde-launchpad repo

### DIFF
--- a/repos/linuxdeepin/dde-launchpad.json
+++ b/repos/linuxdeepin/dde-launchpad.json
@@ -1,0 +1,85 @@
+[
+  {
+    "branches": [
+      "master",
+      "develop/.+",
+      "release/.+"
+    ],
+    "src": "workflow-templates/backup-to-gitlab.yml",
+    "dest": "linuxdeepin/dde-launchpad/.github/workflows/backup-to-gitlab.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "develop/.+",
+      "release/.+"
+    ],
+    "src": "workflow-templates/call-commitlint.yml",
+    "dest": "linuxdeepin/dde-launchpad/.github/workflows/call-commitlint.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "develop/.+",
+      "release/.+"
+    ],
+    "src": "workflow-templates/call-chatOps.yml",
+    "dest": "linuxdeepin/dde-launchpad/.github/workflows/call-chatOps.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "develop/.+",
+      "release/.+"
+    ],
+    "src": "workflow-templates/cppcheck.yml",
+    "dest": "linuxdeepin/dde-launchpad/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "develop/.+",
+      "release/.+"
+    ],
+    "src": "workflow-templates/call-build-deb.yml",
+    "deletelist": [
+      ".github/workflows/call-build-deb.yml"
+    ],
+    "dest": "linuxdeepin/dde-launchpad/.github/workflows/call-build-deb.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "develop/.+",
+      "release/.+"
+    ],
+    "src": "workflow-templates/call-clacheck.yml",
+    "dest": "linuxdeepin/dde-launchpad/.github/workflows/call-clacheck.yml"
+  },
+  {
+    "branches": [
+      "master",
+      "develop/.+",
+      "release/.+"
+    ],
+    "src": "workflow-templates/call-license-check.yml",
+    "dest": "linuxdeepin/dde-launchpad/.github/workflows/call-license-check.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-auto-tag.yml",
+    "dest": "linuxdeepin/dde-launchpad/.github/workflows/call-auto-tag.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-tag-build.yml",
+    "deletelist": [
+      ".github/workflows/call-tag-build.yml"
+    ],
+    "dest": "linuxdeepin/dde-launchpad/.github/workflows/call-tag-build.yml"
+  }
+]


### PR DESCRIPTION
为 dde-launchpad 添加 CI 配置。

注：分支保护未配置，目前可能会有较短的一小段周期会直接往 master 推更新。技术预览版发布后再配置分支保护。

