### PR TITLE
fix(CI): integrate pr commit content incorrect

### DIFF
--- a/.github/workflows/auto-integration-pr.yml
+++ b/.github/workflows/auto-integration-pr.yml
@@ -186,13 +186,18 @@ jobs:
                 }
             });
 
+            console.log("finally repos: ", integrationContent.repos)
             console.log("finally auotintegrationbranch: " + auotintegrationbranch)
             core.setOutput('branch', auotintegrationbranch)
             core.setOutput('prnumber', context.issue.number)
+            if (shell.exec(`git checkout master`).code !== 0) {
+              console.log("warn: checkout master branch failed")
+            }
 
       - name: Remove node_modules dir
         run: |
           rm -rf node_modules package-lock.json package.json
+          git diff .
 
       - name: Create or update integration pr
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
peter-evans/create-pull-request 指定的base和当前工作分支不一样会进行rebase merge操作,导致实际提交内容的变更

log: