### PR TITLE
fix: GITHUB_REF is null

### DIFF
--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
           rm /etc/apt/sources.list
+          GITHUB_REF="${{ github.ref }}"
           branch=${GITHUB_REF#refs/heads/}
           if [[ "$branch" =~ ^"topic-" ]]; then
             trimedBranch=${branch#topic-}


### PR DESCRIPTION
Environment variable GITHUB_REF should be set by action. But doc-check uses a container, environment variables are not inherited by this container. As github context is just a string substitute. It will works in every workflow. Use the github.ref(same as GITHUB_REF) instead to populate GITHUB_REF.

Log: fix GITHUB_REF is null