### PR TITLE
chore(CI): Remove deepin-upgrade-manager cppcheck workflow

### DIFF
--- a/repos/linuxdeepin/deepin-upgrade-manager.json
+++ b/repos/linuxdeepin/deepin-upgrade-manager.json
@@ -24,13 +24,6 @@
     "branches": [
       "master"
     ],
-    "src": "workflow-templates/cppcheck.yml",
-    "dest": "linuxdeepin/deepin-upgrade-manager/.github/workflows/cppcheck.yml"
-  },
-  {
-    "branches": [
-      "master"
-    ],
     "src": "workflow-templates/call-build-deb.yml",
     "deletelist": [
       ".github/workflows/call-build-deb.yml"


### PR DESCRIPTION
is golang language project, need ignore cppcheck

log: