### PR TITLE
fix(CI): fix for /forcemerge get github token error

### DIFF
--- a/.github/workflows/chatOps.yml
+++ b/.github/workflows/chatOps.yml
@@ -110,14 +110,16 @@ jobs:
       # auto merge pull request
       - name: install depends for load scripts
         if: |
-          startsWith(github.event.comment.body, '/merge') || startsWith(github.event.comment.body, '/check')
+          startsWith(github.event.comment.body, '/merge') || startsWith(github.event.comment.body, '/check') ||
+          startsWith(github.event.comment.body, '/forcemerge')
         run: |
           npm install @octokit/rest
           npm install @octokit/auth-app
 
       - name: Get token using github-script
         if: |
-          startsWith(github.event.comment.body, '/merge') || startsWith(github.event.comment.body, '/check')
+          startsWith(github.event.comment.body, '/merge') || startsWith(github.event.comment.body, '/check') ||
+          startsWith(github.event.comment.body, '/forcemerge')
         id: get-token
         uses: actions/github-script@v6
         with:


### PR DESCRIPTION
get-token step skiped when use /forcemerge

log: