### PR TITLE
fix(CI): apt sources.list error

### DIFF
--- a/.github/workflows/dtk-unittest.yml
+++ b/.github/workflows/dtk-unittest.yml
@@ -31,7 +31,7 @@ jobs:
 
         run: |
           echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-          echo "deb [trusted=yes] https://community-packages.deepin.com/beige/ beige main community commercial" >> /etc/apt/sources.list
+          echo "deb [trusted=yes] https://community-packages.deepin.com/beige/ beige main community commercial" > /etc/apt/sources.list
           echo "deb-src [trusted=yes] https://community-packages.deepin.com/beige/ beige main community commercial" >> /etc/apt/sources.list
           echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/deepin:/Develop:/community/deepin_develop/ ./" >> /etc/apt/sources.list
           echo "deb-src [trusted=yes] https://ci.deepin.com/repo/obs/deepin:/Develop:/community/deepin_develop/ ./" >> /etc/apt/sources.list


### PR DESCRIPTION
linuxdeepin/beige 镜像中可能包含不能公开访问的仓库地址,这里统一做覆盖操作