### PR TITLE
chore: add permission for deepin-ci-robot

### DIFF
--- a/teams.yaml
+++ b/teams.yaml
@@ -324,6 +324,7 @@ teams:
       - ComixHe
       - 18202781743
       - FeiWang1119
+      - deepin-ci-robot
     repositories_permissions:
       push:
         - dtk


### PR DESCRIPTION
Add permission for deepin-ci-robot.

Log: add permission for deepin-ci-robot