### PR TITLE
chore: Add triage permissions to deepin-boot-maker group

### DIFF
--- a/teams.yaml
+++ b/teams.yaml
@@ -509,6 +509,8 @@ teams:
       - wanjian1
       - Fire-dtx
     repositories_permissions:
+      triage:
+        - developer-center
       push:
         - deepin-boot-maker
   - name: dde-control-center


### PR DESCRIPTION
In order to align issues to the group members

Log: Add triage permissions to deepin-boot-maker group