### PR TITLE
chore: add wineee to deepin-kwin team

### DIFF
--- a/teams.yaml
+++ b/teams.yaml
@@ -531,6 +531,7 @@ teams:
       - ChaojiangLuo
       - zhangyaninga
       - zy-seven
+      - wineee
     repositories_permissions:
       push:
         - dwayland
@@ -554,6 +555,7 @@ teams:
       - xyruos
       - guokaka
       - san-Hei
+      - wineee
     repositories_permissions:
       triage:
         - dwayland


### PR DESCRIPTION
Log: add `wineee` to deepin-kwin-member and deepin-kwin team