### PR TITLE
chore: move 52cyb to dde-maintainer team

### DIFF
--- a/teams.yaml
+++ b/teams.yaml
@@ -33,6 +33,7 @@ teams:
       - waterlovemelon
       - Ivy233
       - ut005973
+      - 52cyb
     repositories_permissions:
       triage:
         - developer-center


### PR DESCRIPTION
chore: move 52cyb to dde-maintainer team

## Summary by Sourcery

Chores:
- Update team membership configuration to include 52cyb in dde-maintainer.