### PR TITLE
fix: use merge_commit_sha instead of head.sha for auto-tag

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -134,7 +134,7 @@ jobs:
               return
             }
             let data
-            const mergeCommitSha = context.payload.pull_request.head.sha
+            const mergeCommitSha = context.payload.pull_request.merge_commit_sha
             try {
               const tagResult = await github.rest.git.createTag({
                 repo: context.repo.repo,


### PR DESCRIPTION
    解决创建的tag无法找到对用的分支的问题

Log: