### PR TITLE
fix: extend AI co-author pattern check with more model names

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          BLOCKED_PATTERN='Co-authored-by:.*ai|Co-authored-by:.*agent|Co-authored-by:.*copilot|Co-authored-by:.*llm|Co-authored-by:.*gpt'
+          BLOCKED_PATTERN='Co-authored-by:.*ai|Co-authored-by:.*agent|Co-authored-by:.*copilot|Co-authored-by:.*llm|Co-authored-by:.*gpt|Co-authored-by:.*claude|Co-authored-by:.*anthropic|Co-authored-by:.*openai|Co-authored-by:.*chatgpt|Co-authored-by:.*gemini|Co-authored-by:.*deepseek|Co-authored-by:.*mistral|Co-authored-by:.*llama|Co-authored-by:.*codestral'
           if echo "${PR_BODY}" | grep -Eiq "${BLOCKED_PATTERN}"; then
             echo "FAIL: PR description contains blocked co-author AI pattern." >&2
             echo "Blocked pattern: ${BLOCKED_PATTERN}" >&2
@@ -29,7 +29,7 @@ jobs:
       - name: check commit messages for AI co-author pattern
         shell: bash
         run: |
-          BLOCKED_PATTERN='Co-authored-by:.*ai|Co-authored-by:.*agent|Co-authored-by:.*copilot|Co-authored-by:.*llm|Co-authored-by:.*gpt'
+          BLOCKED_PATTERN='Co-authored-by:.*ai|Co-authored-by:.*agent|Co-authored-by:.*copilot|Co-authored-by:.*llm|Co-authored-by:.*gpt|Co-authored-by:.*claude|Co-authored-by:.*anthropic|Co-authored-by:.*openai|Co-authored-by:.*chatgpt|Co-authored-by:.*gemini|Co-authored-by:.*deepseek|Co-authored-by:.*mistral|Co-authored-by:.*llama|Co-authored-by:.*codestral'
           COMMIT_MSGS=$(git log --format=%B ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} 2>/dev/null || true)
           if [[ -n "${COMMIT_MSGS}" ]] && echo "${COMMIT_MSGS}" | grep -Eiq "${BLOCKED_PATTERN}"; then
             echo "FAIL: Commit messages contain blocked co-author AI pattern." >&2


### PR DESCRIPTION
Add claude, anthropic, openai, chatgpt, gemini, deepseek, mistral, llama, codestral to the blocked co-author pattern list to catch more AI-generated co-author lines.

## Summary by Sourcery

Build:
- Update commitlint GitHub Actions workflow to block co-author lines referencing additional AI tools and models.