### PR TITLE
Add workflow to automate changelog updates

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,305 @@
+name: update changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Target version; leave empty to auto bump from debian/changelog"
+        required: false
+        type: string
+      name:
+        description: "Maintainer name used in debian/changelog"
+        required: true
+        type: string
+      email:
+        description: "Maintainer email used in debian/changelog"
+        required: true
+        type: string
+      base_branch:
+        description: "Base branch to read and target"
+        required: false
+        default: master
+        type: string
+      distribution:
+        description: "Changelog distribution"
+        required: false
+        default: unstable
+        type: string
+      create_pr:
+        description: "Create a pull request after generating changelog"
+        required: false
+        default: true
+        type: boolean
+  workflow_call:
+    inputs:
+      version:
+        required: false
+        type: string
+      name:
+        required: true
+        type: string
+      email:
+        required: true
+        type: string
+      base_branch:
+        required: false
+        type: string
+        default: master
+      distribution:
+        required: false
+        type: string
+        default: unstable
+      create_pr:
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      APP_ID:
+        required: false
+      APP_PRIVATE_KEY:
+        required: false
+    outputs:
+      pr_url:
+        value: ${{ jobs.update_changelog.outputs.pr_url }}
+      pr_number:
+        value: ${{ jobs.update_changelog.outputs.pr_number }}
+      version:
+        value: ${{ jobs.update_changelog.outputs.version }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_changelog:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_url: ${{ steps.create_pr.outputs.pull-request-url }}
+      pr_number: ${{ steps.create_pr.outputs.pull-request-number }}
+      version: ${{ steps.prepare.outputs.version }}
+    steps:
+      - name: Create GitHub App token
+        id: app_token
+        if: ${{ inputs.create_pr }}
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout base branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.base_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install changelog tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y devscripts
+
+      - name: Prepare changelog data
+        id: prepare
+        shell: python
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_BASE_BRANCH: ${{ inputs.base_branch }}
+          INPUT_DISTRIBUTION: ${{ inputs.distribution }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token || github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          import json
+          import os
+          import pathlib
+          import re
+          import subprocess
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          def output_line(name, value):
+              with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+                  fh.write(f"{name}={value}\n")
+
+          def get_current_version(changelog_path):
+              try:
+                  result = subprocess.run(
+                      ["dpkg-parsechangelog", "-l", str(changelog_path), "-S", "Version"],
+                      capture_output=True,
+                      text=True,
+                      check=True,
+                  )
+                  return result.stdout.strip()
+              except Exception:
+                  first_line = changelog_path.read_text(encoding="utf-8").splitlines()[0].strip()
+                  match = re.match(r"^[^(]+\(([^)]+)\)", first_line)
+                  if not match:
+                      raise RuntimeError(f"cannot parse version from {changelog_path}")
+                  return match.group(1)
+
+          def bump_version(version):
+              epoch = ""
+              value = version
+              if ":" in value:
+                  epoch_part, value = value.split(":", 1)
+                  if epoch_part.isdigit():
+                      epoch = epoch_part + ":"
+              if "-" in value:
+                  value = value.rsplit("-", 1)[0]
+              parts = value.split(".")
+              if len(parts) < 2 or any(not part.isdigit() for part in parts):
+                  raise RuntimeError(
+                      "cannot auto bump complex Debian version "
+                      f"{version!r}; pass the workflow input 'version' explicitly"
+                  )
+              parts[-1] = str(int(parts[-1]) + 1)
+              return epoch + ".".join(parts)
+
+          def github_get(url):
+              headers = {
+                  "Accept": "application/vnd.github+json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+                  "User-Agent": "deepin-autopack-update-changelog",
+                  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+              }
+              req = urllib.request.Request(url, headers=headers)
+              try:
+                  with urllib.request.urlopen(req, timeout=30) as resp:
+                      body = resp.read().decode("utf-8")
+                      data = json.loads(body) if body else None
+                      resp_headers = {k.lower(): v for k, v in resp.headers.items()}
+                      return data, resp_headers
+              except urllib.error.HTTPError as exc:
+                  body = exc.read().decode("utf-8", errors="replace")
+                  if len(body) > 2000:
+                      body = body[:2000] + "...<truncated>"
+                  raise RuntimeError(
+                      f"GitHub API request failed: status={exc.code}, url={url}, body={body}"
+                  ) from exc
+
+          def parse_link_header(value):
+              links = {}
+              if not value:
+                  return links
+              for item in value.split(","):
+                  item = item.strip()
+                  match = re.match(r'<([^>]+)>;\s*rel="([^"]+)"', item)
+                  if match:
+                      links[match.group(2)] = match.group(1)
+              return links
+
+          def commit_titles_since_changelog(owner, repo, base_branch, head_sha):
+              base_url = f"https://api.github.com/repos/{owner}/{repo}"
+              commits_url = f"{base_url}/commits?{urllib.parse.urlencode({'sha': base_branch, 'path': 'debian/changelog', 'per_page': 1})}"
+              commits, _ = github_get(commits_url)
+              if not commits:
+                  raise RuntimeError(f"no commit found for debian/changelog on {base_branch}")
+
+              base_sha = commits[0]["sha"]
+              compare_url = f"{base_url}/compare/{urllib.parse.quote(base_sha, safe='')}...{urllib.parse.quote(head_sha, safe='')}?per_page=100"
+              titles = []
+              next_url = compare_url
+              while next_url:
+                  page, page_headers = github_get(next_url)
+                  for item in page.get("commits", []):
+                      message = item.get("commit", {}).get("message", "")
+                      title = message.splitlines()[0].strip()
+                      if title:
+                          titles.append(title)
+                  next_url = parse_link_header(page_headers.get("link")).get("next")
+              return base_sha, titles
+
+          repo_root = pathlib.Path(os.environ["GITHUB_WORKSPACE"])
+          changelog_path = repo_root / "debian" / "changelog"
+          if not changelog_path.exists():
+              raise RuntimeError(f"missing changelog: {changelog_path}")
+
+          requested_version = os.environ.get("INPUT_VERSION", "").strip()
+          distribution = os.environ.get("INPUT_DISTRIBUTION", "").strip() or "unstable"
+          base_branch = os.environ.get("INPUT_BASE_BRANCH", "").strip() or "master"
+          owner, repo = os.environ["GITHUB_REPOSITORY"].split("/", 1)
+          head_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+
+          current_version = get_current_version(changelog_path)
+          version = requested_version or bump_version(current_version)
+          if not version:
+              raise RuntimeError(f"unable to determine version from {current_version!r}")
+
+          base_sha, titles = commit_titles_since_changelog(owner, repo, base_branch, head_sha)
+          safe_version = re.sub(r"[^A-Za-z0-9._-]+", "-", version).strip("-")
+
+          output_line("version", version)
+          output_line("safe_version", safe_version)
+          output_line("distribution", distribution)
+          output_line("base_branch", base_branch)
+          output_line("base_sha", base_sha)
+          output_line("head_sha", head_sha)
+          output_line("titles_json", json.dumps(titles, ensure_ascii=False))
+
+      - name: Generate changelog
+        shell: python
+        env:
+          VERSION: ${{ steps.prepare.outputs.version }}
+          DISTRIBUTION: ${{ steps.prepare.outputs.distribution }}
+          TITLES_JSON: ${{ steps.prepare.outputs.titles_json }}
+          DEBFULLNAME: ${{ inputs.name }}
+          DEBEMAIL: ${{ inputs.email }}
+          TZ: Asia/Shanghai
+        run: |
+          import json
+          import os
+          import subprocess
+
+          version = os.environ["VERSION"].strip()
+          distribution = os.environ["DISTRIBUTION"].strip() or "unstable"
+          titles = json.loads(os.environ["TITLES_JSON"])
+          if not titles:
+              titles = [f"Release {version}"]
+
+          subprocess.run(
+              ["dch", "-v", version, "-D", distribution, titles[0]],
+              check=True,
+          )
+          for title in titles[1:]:
+              subprocess.run(["dch", "-a", title], check=True)
+
+      - name: Show changelog diff
+        if: ${{ !inputs.create_pr }}
+        run: git diff -- debian/changelog
+
+      - name: Upload generated changelog
+        if: ${{ !inputs.create_pr }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-changelog
+          path: debian/changelog
+
+      - name: Create pull request
+        id: create_pr
+        if: ${{ inputs.create_pr }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ steps.app_token.outputs.token }}
+          branch: automation/update-changelog/${{ steps.prepare.outputs.safe_version }}
+          title: "chore: update changelog to ${{ steps.prepare.outputs.version }}"
+          commit-message: "chore: update changelog to ${{ steps.prepare.outputs.version }}"
+          body: |
+            Automated changelog update.
+
+            - Version: `${{ steps.prepare.outputs.version }}`
+            - Base branch: `${{ steps.prepare.outputs.base_branch }}`
+            - Base changelog commit: `${{ steps.prepare.outputs.base_sha }}`
+            - Head commit: `${{ steps.prepare.outputs.head_sha }}`
+          add-paths: |
+            debian/changelog
+          delete-branch: true
+
+      - name: Show pull request result
+        if: ${{ inputs.create_pr }}
+        run: |
+          echo "Version: ${{ steps.prepare.outputs.version }}"
+          echo "Pull Request Number: ${{ steps.create_pr.outputs.pull-request-number }}"
+          echo "Pull Request URL: ${{ steps.create_pr.outputs.pull-request-url }}"

--- a/repos/linuxdeepin/dcc-insider-plugin.json
+++ b/repos/linuxdeepin/dcc-insider-plugin.json
@@ -69,5 +69,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dcc-insider-plugin/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dcc-insider-plugin/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-account-faces.json
+++ b/repos/linuxdeepin/dde-account-faces.json
@@ -67,5 +67,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-account-faces/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-account-faces/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-api-proxy.json
+++ b/repos/linuxdeepin/dde-api-proxy.json
@@ -57,5 +57,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-api-proxy/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-api-proxy/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-api.json
+++ b/repos/linuxdeepin/dde-api.json
@@ -67,5 +67,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-api/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-api/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-app-services.json
+++ b/repos/linuxdeepin/dde-app-services.json
@@ -92,5 +92,12 @@
     ],
     "src": "issue-templates/unit-test-report.md",
     "dest": "linuxdeepin/dde-app-services/.github/ISSUE_TEMPLATE/unit-test-report.md"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-app-services/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-appearance.json
+++ b/repos/linuxdeepin/dde-appearance.json
@@ -57,5 +57,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-appearance/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-appearance/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-application-manager.json
+++ b/repos/linuxdeepin/dde-application-manager.json
@@ -57,5 +57,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-application-manager/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-application-manager/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-application-wizard.json
+++ b/repos/linuxdeepin/dde-application-wizard.json
@@ -60,5 +60,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-application-wizard/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-application-wizard/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-clipboard.json
+++ b/repos/linuxdeepin/dde-clipboard.json
@@ -88,5 +88,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-clipboard/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-clipboard/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-control-center.json
+++ b/repos/linuxdeepin/dde-control-center.json
@@ -83,5 +83,12 @@
     ],
     "src": "workflow-templates/call-deploy-dev-doc.yml",
     "dest": "linuxdeepin/dde-control-center/.github/workflows/call-deploy-dev-doc.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-control-center/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-daemon.json
+++ b/repos/linuxdeepin/dde-daemon.json
@@ -67,5 +67,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-daemon/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-daemon/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-launchpad.json
+++ b/repos/linuxdeepin/dde-launchpad.json
@@ -69,5 +69,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-launchpad/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-launchpad/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-manual-content.json
+++ b/repos/linuxdeepin/dde-manual-content.json
@@ -81,5 +81,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-manual-content/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-manual-content/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-network-core.json
+++ b/repos/linuxdeepin/dde-network-core.json
@@ -88,5 +88,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-network-core/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-network-core/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-polkit-agent.json
+++ b/repos/linuxdeepin/dde-polkit-agent.json
@@ -88,5 +88,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-polkit-agent/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-polkit-agent/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-session-shell.json
+++ b/repos/linuxdeepin/dde-session-shell.json
@@ -74,5 +74,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-session-shell/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-session-shell/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-session-ui.json
+++ b/repos/linuxdeepin/dde-session-ui.json
@@ -74,5 +74,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-session-ui/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-session-ui/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-session.json
+++ b/repos/linuxdeepin/dde-session.json
@@ -57,5 +57,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-session/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-session/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-shell.json
+++ b/repos/linuxdeepin/dde-shell.json
@@ -69,5 +69,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-shell/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-shell/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/ddm.json
+++ b/repos/linuxdeepin/ddm.json
@@ -67,6 +67,13 @@
     ],
     "src": "workflow-templates/cppcheck.yml",
     "dest": "linuxdeepin/ddm/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/ddm/.github/workflows/call-update-changelog.yml"
   }
 ]
 

--- a/repos/linuxdeepin/deepin-desktop-theme.json
+++ b/repos/linuxdeepin/deepin-desktop-theme.json
@@ -57,5 +57,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-desktop-theme/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-desktop-theme/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-face.json
+++ b/repos/linuxdeepin/deepin-face.json
@@ -81,5 +81,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-face/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-face/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-gtk-theme.json
+++ b/repos/linuxdeepin/deepin-gtk-theme.json
@@ -85,5 +85,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-gtk-theme/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-gtk-theme/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-icon-theme.json
+++ b/repos/linuxdeepin/deepin-icon-theme.json
@@ -67,5 +67,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-icon-theme/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-icon-theme/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-pw-check.json
+++ b/repos/linuxdeepin/deepin-pw-check.json
@@ -74,5 +74,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-pw-check/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-pw-check/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-screensaver.json
+++ b/repos/linuxdeepin/deepin-screensaver.json
@@ -82,5 +82,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-screensaver/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-screensaver/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-service-manager.json
+++ b/repos/linuxdeepin/deepin-service-manager.json
@@ -82,5 +82,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-service-manager/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-service-manager/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-sound-theme.json
+++ b/repos/linuxdeepin/deepin-sound-theme.json
@@ -67,5 +67,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-sound-theme/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-sound-theme/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-update-ui.json
+++ b/repos/linuxdeepin/deepin-update-ui.json
@@ -60,5 +60,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-update-ui/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-update-ui/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-wallpapers.json
+++ b/repos/linuxdeepin/deepin-wallpapers.json
@@ -79,5 +79,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-wallpapers/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-wallpapers/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/treeland-protocols.json
+++ b/repos/linuxdeepin/treeland-protocols.json
@@ -58,6 +58,13 @@
     ],
     "src": "workflow-templates/cppcheck.yml",
     "dest": "linuxdeepin/treeland-protocols/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/treeland-protocols/.github/workflows/call-update-changelog.yml"
   }
 ]
 

--- a/repos/linuxdeepin/treeland.json
+++ b/repos/linuxdeepin/treeland.json
@@ -67,6 +67,13 @@
     ],
     "src": "workflow-templates/cppcheck.yml",
     "dest": "linuxdeepin/treeland/.github/workflows/cppcheck.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/treeland/.github/workflows/call-update-changelog.yml"
   }
 ]
 

--- a/repos/linuxdeepin/xdg-desktop-portal-dde.json
+++ b/repos/linuxdeepin/xdg-desktop-portal-dde.json
@@ -57,5 +57,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/xdg-desktop-portal-dde/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/xdg-desktop-portal-dde/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/workflow-templates/call-update-changelog.yml
+++ b/workflow-templates/call-update-changelog.yml
@@ -1,0 +1,53 @@
+name: Call update changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Target version; leave empty to auto bump"
+        required: false
+        type: string
+      name:
+        description: "Maintainer name used in debian/changelog"
+        required: true
+        type: string
+      email:
+        description: "Maintainer email used in debian/changelog"
+        required: true
+        type: string
+      base_branch:
+        description: "Base branch to read and target"
+        required: false
+        default: master
+        type: string
+      distribution:
+        description: "Changelog distribution"
+        required: false
+        default: unstable
+        type: string
+      create_pr:
+        description: "Create a pull request after generating changelog"
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  update_changelog:
+    uses: linuxdeepin/.github/.github/workflows/update-changelog.yml@master
+    with:
+      version: ${{ inputs.version }}
+      name: ${{ inputs.name }}
+      email: ${{ inputs.email }}
+      base_branch: ${{ inputs.base_branch }}
+      distribution: ${{ inputs.distribution }}
+      create_pr: ${{ inputs.create_pr }}
+    secrets: inherit
+
+  show_result:
+    runs-on: ubuntu-latest
+    needs: update_changelog
+    steps:
+      - name: Show update changelog result
+        run: |
+          echo "Version: ${{ needs.update_changelog.outputs.version }}"
+          echo "Pull Request URL: ${{ needs.update_changelog.outputs.pr_url }}"


### PR DESCRIPTION
This workflow automates the process of updating the changelog based on commits since the last changelog entry. It includes options for versioning, maintainer details, and creating a pull request for the updated changelog.

这个可复用 workflow 用于自动更新 Debian `debian/changelog`。

它会在目标基础分支上查找最近一次修改 `debian/changelog` 的提交，收集该提交之后的提交标题，并使用 `dch` 生成新的 changelog 条目。目标版本号可以通过 `version` 输入手动指定。如果没有指定 `version`，workflow 会尝试自动递增简单的数字版本号，例如 `1.2.3`、`1:1.2.3` 或 `1.2.3-1`。

对于 `1.2.3~rc1`、`1.2.3a`、`1.2.3+deepin` 这类复杂 Debian 版本号，workflow 不会猜测下一个版本号，而是会给出明确错误，并要求调用方显式传入 `version`。

主要功能：

- 支持手动触发，也支持作为可复用 workflow 被其他仓库调用。
- 支持设置目标版本号、维护者姓名、维护者邮箱、基础分支和 changelog distribution。
- 读取 GitHub 提交数据，并根据提交标题生成 changelog 条目。
- 可以自动创建包含 changelog 更新的 Pull Request。
- 也可以跳过 Pull Request 创建，仅将生成后的 changelog 作为 artifact 上传。
- 当 GitHub API 请求失败时，会输出状态码、请求 URL 和截断后的响应内容，方便定位 CI 失败原因。


暂时只给 dde 和 treeland维护的项目增加这个workflow

**自动提升版本号的功能没有办法覆盖所有情况，一定要仔细甄别PR的版本号是否合理**

## Summary by Sourcery

Add a reusable GitHub Actions workflow to automatically update the Debian changelog from recent commit titles and optionally open a pull request with the changes.

New Features:
- Introduce a manually-triggered and callable workflow for generating Debian changelog entries from commits since the last changelog update.
- Allow configuration of target version, base branch, distribution, and maintainer identity when generating changelog entries.
- Automatically create a versioned changelog update branch and pull request for the generated changelog changes, exposing the PR metadata as workflow outputs.

Enhancements:
- Fallback to artifact upload and diff display of the generated changelog when pull request creation is disabled.