### PR TITLE
chore(repos): add update-changelog workflow for 4 repos

### DIFF
--- a/repos/linuxdeepin/dde-services.json
+++ b/repos/linuxdeepin/dde-services.json
@@ -1,0 +1,9 @@
+[
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-services/.github/workflows/call-update-changelog.yml"
+  }
+]

--- a/repos/linuxdeepin/dde-session-shell-snipe.json
+++ b/repos/linuxdeepin/dde-session-shell-snipe.json
@@ -1,0 +1,9 @@
+[
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-session-shell-snipe/.github/workflows/call-update-changelog.yml"
+  }
+]

--- a/repos/linuxdeepin/dde-tray-loader.json
+++ b/repos/linuxdeepin/dde-tray-loader.json
@@ -50,5 +50,12 @@
     ],
     "src": "workflow-templates/call-auto-tag.yml",
     "dest": "linuxdeepin/dde-tray-loader/.github/workflows/call-auto-tag.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-tray-loader/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/go-dbus-factory.json
+++ b/repos/linuxdeepin/go-dbus-factory.json
@@ -62,6 +62,13 @@
     "branch": [
       "master"
     ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/go-dbus-factory/.github/workflows/call-update-changelog.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
     "src": "workflow-templates/call-tag-build.yml",
     "deletelist": [
       ".github/workflows/call-tag-build.yml"


### PR DESCRIPTION
1. Add call-update-changelog entry to dde-tray-loader and go-dbus-factory
2. Create new repo config for dde-services with call-update-changelog
3. Create new repo config for dde-session-shell-snipe with call-update-changelog

Log: add call-update-changelog workflow to dde-services, dde-tray-loader, go-dbus-factory and dde-session-shell-snipe

chore(repos): 为 4 个仓库添加 update-changelog 工作流

1. 为 dde-tray-loader 和 go-dbus-factory 追加 call-update-changelog 条目
2. 新建 dde-services 仓库配置，包含 call-update-changelog
3. 新建 dde-session-shell-snipe 仓库配置，包含 call-update-changelog

Log: 为 dde-services、dde-tray-loader、go-dbus-factory 和 dde-session-shell-snipe 添加 call-update-changelog 工作流

## Summary by Sourcery

Add update-changelog workflow configuration for multiple linuxdeepin repositories.

Chores:
- Add call-update-changelog entries to existing dde-tray-loader and go-dbus-factory repository configs.
- Introduce new repository configs for dde-services and dde-session-shell-snipe with call-update-changelog enabled.