### PR TITLE
fix: use branch ref instead of SHA for actions/checkout@v7

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/heads/${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           allow-unsafe-pr-checkout: true
           persist-credentials: false

--- a/.github/workflows/build-distribution.yml
+++ b/.github/workflows/build-distribution.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v7
         if: ${{ github.event.pull_request.head.sha }}
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/heads/${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           allow-unsafe-pr-checkout: true
       - uses: actions/checkout@v7
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v7
         if: ${{ github.event.pull_request.head.sha }}
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/heads/${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           allow-unsafe-pr-checkout: true
       - uses: actions/checkout@v7
@@ -164,7 +164,7 @@ jobs:
       - uses: actions/checkout@v7
         if: ${{ github.event.pull_request.head.sha }}
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/heads/${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           allow-unsafe-pr-checkout: true
       - uses: actions/checkout@v7
@@ -370,7 +370,7 @@ jobs:
       - uses: actions/checkout@v7
         if: ${{ github.event.pull_request.head.sha }}
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/heads/${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           allow-unsafe-pr-checkout: true
       - uses: actions/checkout@v7

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Fetch code
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/heads/${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           allow-unsafe-pr-checkout: true
           fetch-depth: 0

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/heads/${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           allow-unsafe-pr-checkout: true
           persist-credentials: false

--- a/.github/workflows/dtk-unittest.yml
+++ b/.github/workflows/dtk-unittest.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v7
         if: ${{ github.event.pull_request.head.sha }}
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/heads/${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           allow-unsafe-pr-checkout: true
       - uses: actions/checkout@v7

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -9,7 +9,7 @@ jobs:
         with:
           # fetch-depth: 0 必不可少，否则 git diff 找不到对比基准
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/heads/${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           allow-unsafe-pr-checkout: true
 
@@ -117,7 +117,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/heads/${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           allow-unsafe-pr-checkout: true
       - name: Install zsh
@@ -150,7 +150,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/heads/${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           allow-unsafe-pr-checkout: true
       - uses: zccrs/github-actions-spdx-checker@main

--- a/workflow-templates/cppcheck.yml
+++ b/workflow-templates/cppcheck.yml
@@ -16,7 +16,7 @@ jobs:
       - run: export
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/heads/${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           allow-unsafe-pr-checkout: true
           persist-credentials: false


### PR DESCRIPTION
## 问题

`actions/checkout@v7` 在使用 `ref: ${{ github.event.pull_request.head.sha }}` 时存在缺陷：

1. **`getRefSpec` 对 SHA 只 fetch 单个 commit**，不拉取完整分支历史
2. **`testRef` 对 SHA 永远返回 true**，不会触发第二次 targeted fetch
3. 当 PR 分支使用 `git commit --amend` 后，新的 commit SHA 不在本地 git 历史中，导致后续 `git diff base...head` 等命令失败

## 修复

将 `ref` 参数从裸 SHA 改为 `refs/heads/<branch>` 格式，使 `getRefSpecForAllHistory` 能正确处理分支 ref，`testRef` 也能在 force-push 后正确检测到 ref 变化并触发第二次 fetch。

## 变更文件

| 文件 | 修改处数 |
|------|---------|
| `.github/workflows/license-check.yml` | 3 |
| `.github/workflows/build-distribution.yml` | 4 |
| `.github/workflows/auto-tag.yml` | 1 |
| `.github/workflows/commitlint.yml` | 1 |
| `.github/workflows/doc-check.yml` | 1 |
| `.github/workflows/dtk-unittest.yml` | 1 |
| `workflow-templates/cppcheck.yml` | 1 |

## 相关 PR

- https://github.com/linuxdeepin/deepin-update-ui/pull/325

## Summary by Sourcery

Update GitHub Actions workflows to check out pull request branches by ref name instead of commit SHA to ensure full history and correct behavior after force-pushes.

Bug Fixes:
- Fix pull request checkout issues caused by using head commit SHA, which could leave new commits missing from local history and break diff-based steps.

CI:
- Adjust multiple GitHub Actions workflows to pass branch refs (refs/heads/<branch>) to actions/checkout@v7 when handling pull requests.