### PR TITLE
fix: testing repo access 404 error

### DIFF
--- a/.github/workflows/deploy-dev-doc.yml
+++ b/.github/workflows/deploy-dev-doc.yml
@@ -33,8 +33,8 @@ jobs:
           rm /etc/apt/sources.list
           echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/deepin:/Develop:/dde/deepin_develop/ ./" > /etc/apt/sources.list
           echo "deb-src [trusted=yes] https://ci.deepin.com/repo/obs/deepin:/Develop:/dde/deepin_develop/ ./" >> /etc/apt/sources.list
-          echo "deb [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/testing/ unstable main dde community commercial" >> /etc/apt/sources.list
-          echo "deb-src [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/testing/ unstable main dde community commercial" >> /etc/apt/sources.list
+          echo "deb [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/testing/ unstable main community commercial" >> /etc/apt/sources.list
+          echo "deb-src [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/testing/ unstable main community commercial" >> /etc/apt/sources.list
           echo "deb [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/stable/ beige main community commercial" >> /etc/apt/sources.list
           echo "deb-src [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/stable/ beige main community commercial" >> /etc/apt/sources.list
           apt-get update && apt-get install -y --force-yes ca-certificates apt-transport-https sudo


### PR DESCRIPTION
testing仓库的dde组件被去掉了，因此在这个里面也去掉。

## Summary by Sourcery

Build:
- Adjust APT testing repository entries in dev docs deployment workflow to drop the deprecated dde component section.