### PR TITLE
chore: update repo dist code to crimson

### DIFF
--- a/.github/workflows/deploy-dev-doc.yml
+++ b/.github/workflows/deploy-dev-doc.yml
@@ -35,8 +35,8 @@ jobs:
           echo "deb-src [trusted=yes] https://ci.deepin.com/repo/obs/deepin:/Develop:/dde/deepin_develop/ ./" >> /etc/apt/sources.list
           echo "deb [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/testing/ unstable main community commercial" >> /etc/apt/sources.list
           echo "deb-src [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/testing/ unstable main community commercial" >> /etc/apt/sources.list
-          echo "deb [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/stable/ beige main community commercial" >> /etc/apt/sources.list
-          echo "deb-src [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/stable/ beige main community commercial" >> /etc/apt/sources.list
+          echo "deb [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/stable/ crimson main community commercial" >> /etc/apt/sources.list
+          echo "deb-src [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/stable/ crimson main community commercial" >> /etc/apt/sources.list
           apt-get update && apt-get install -y --force-yes ca-certificates apt-transport-https sudo
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
deepin现在已经更新到了25版本，因此更新仓库代号。

## Summary by Sourcery

CI:
- Switch the stable deepin-community APT source in the dev docs deployment workflow from beige to crimson.