### PR TITLE
chore: disable cppcheck CI for treeland-protocols and fix typo (branc…

### DIFF
--- a/repos/linuxdeepin/treeland-protocols.json
+++ b/repos/linuxdeepin/treeland-protocols.json
@@ -1,36 +1,28 @@
 [
   {
     "branch": [
-      "master",
-      "develop/snipe",
-      "release/snipe"
+      "master"
     ],
     "src": "workflow-templates/call-clacheck.yml",
     "dest": "linuxdeepin/treeland-protocols/.github/workflows/call-clacheck.yml"
   },
   {
-    "branche": [
-      "master",
-      "develop/snipe",
-      "release/snipe"
+    "branch": [
+      "master"
     ],
     "src": "workflow-templates/call-commitlint.yml",
     "dest": "linuxdeepin/treeland-protocols/.github/workflows/call-commitlint.yml"
   },
   {
     "branch": [
-      "master",
-      "develop/snipe",
-      "release/snipe"
+      "master"
     ],
     "src": "workflow-templates/call-chatOps.yml",
     "dest": "linuxdeepin/treeland-protocols/.github/workflows/call-chatOps.yml"
   },
   {
-    "branches": [
-      "master",
-      "develop/snipe",
-      "release/snipe"
+    "branch": [
+      "master"
     ],
     "src": "workflow-templates/call-license-check.yml",
     "dest": "linuxdeepin/treeland-protocols/.github/workflows/call-license-check.yml"
@@ -53,13 +45,6 @@
     "dest": "linuxdeepin/treeland-protocols/.github/workflows/call-tag-build.yml"
   },
   {
-    "branches": [
-      "master"
-    ],
-    "src": "workflow-templates/cppcheck.yml",
-    "dest": "linuxdeepin/treeland-protocols/.github/workflows/cppcheck.yml"
-  },
-  {
     "branch": [
       "master"
     ],
@@ -67,5 +52,3 @@
     "dest": "linuxdeepin/treeland-protocols/.github/workflows/call-update-changelog.yml"
   }
 ]
-
-


### PR DESCRIPTION
…he -> branches)

## Summary by Sourcery

Disable cppcheck CI for the treeland-protocols repository and correct a typo in its configuration metadata.

CI:
- Disable cppcheck checks for the linuxdeepin/treeland-protocols repository in the CI configuration.

Chores:
- Fix a typo in the linuxdeepin/treeland-protocols repository configuration metadata.