### PR TITLE
fix: correct 'branche' typo to 'branch'/'branches' in repo configs

### DIFF
--- a/repos/linuxdeepin/ddm.json
+++ b/repos/linuxdeepin/ddm.json
@@ -18,7 +18,7 @@
     "dest": "linuxdeepin/ddm/.github/workflows/call-clacheck.yml"
   },
   {
-    "branche": [
+    "branches": [
       "master",
       "develop/snipe",
       "release/snipe"

--- a/repos/linuxdeepin/linglong-box.json
+++ b/repos/linuxdeepin/linglong-box.json
@@ -18,7 +18,7 @@
     "dest": "linuxdeepin/linglong-box/.github/workflows/call-clacheck.yml"
   },
   {
-    "branche": [
+    "branches": [
       "master",
       "develop/snipe",
       "release/snipe"

--- a/repos/linuxdeepin/linglong-dbus-proxy.json
+++ b/repos/linuxdeepin/linglong-dbus-proxy.json
@@ -18,7 +18,7 @@
     "dest": "linuxdeepin/linglong-dbus-proxy/.github/workflows/call-clacheck.yml"
   },
   {
-    "branche": [
+    "branches": [
       "master",
       "develop/snipe",
       "release/snipe"

--- a/repos/linuxdeepin/linglong-hub.json
+++ b/repos/linuxdeepin/linglong-hub.json
@@ -18,7 +18,7 @@
     "dest": "linuxdeepin/linglong-hub/.github/workflows/call-clacheck.yml"
   },
   {
-    "branche": [
+    "branches": [
       "master",
       "develop/snipe",
       "release/snipe"

--- a/repos/linuxdeepin/linglong-loader.json
+++ b/repos/linuxdeepin/linglong-loader.json
@@ -18,7 +18,7 @@
     "dest": "linuxdeepin/linglong-loader/.github/workflows/call-clacheck.yml"
   },
   {
-    "branche": [
+    "branches": [
       "master",
       "develop/snipe",
       "release/snipe"

--- a/repos/linuxdeepin/linglong-pica.json
+++ b/repos/linuxdeepin/linglong-pica.json
@@ -14,7 +14,7 @@
     "dest": "linuxdeepin/linglong-pica/.github/workflows/call-clacheck.yml"
   },
   {
-    "branche": [
+    "branch": [
       "master"
     ],
     "src": "workflow-templates/call-commitlint.yml",

--- a/repos/linuxdeepin/linglong.json
+++ b/repos/linuxdeepin/linglong.json
@@ -18,7 +18,7 @@
     "dest": "linuxdeepin/linglong/.github/workflows/call-clacheck.yml"
   },
   {
-    "branche": [
+    "branches": [
       "master",
       "develop/snipe",
       "release/snipe"

--- a/repos/linuxdeepin/treeland.json
+++ b/repos/linuxdeepin/treeland.json
@@ -18,7 +18,7 @@
     "dest": "linuxdeepin/treeland/.github/workflows/call-clacheck.yml"
   },
   {
-    "branche": [
+    "branches": [
       "master",
       "develop/snipe",
       "release/snipe"


### PR DESCRIPTION
- linglong-pica: branche -> branch (single branch)
- linglong-dbus-proxy, linglong-hub, ddm, linglong, treeland, linglong-loader, linglong-box: branche -> branches (multiple branches)

## Summary by Sourcery

Fix repository configuration typos in linuxdeepin JSON repo definitions.

Bug Fixes:
- Correct misspelled 'branche' field to 'branch' or 'branches' in multiple linuxdeepin repo config files to ensure proper branch configuration resolution.

Chores:
- Normalize branch-related keys across linuxdeepin repo JSON configs for consistency.