### PR TITLE
feat(changelog): sync linglong.yaml version and enable workflow for app repos

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -232,6 +232,7 @@ jobs:
           safe_version = re.sub(r"[^A-Za-z0-9._-]+", "-", version).strip("-")
 
           output_line("version", version)
+          output_line("current_version", current_version)
           output_line("safe_version", safe_version)
           output_line("distribution", distribution)
           output_line("base_branch", base_branch)
@@ -266,16 +267,104 @@ jobs:
           for title in titles[1:]:
               subprocess.run(["dch", "-a", title], check=True)
 
+      - name: Sync linglong.yaml version
+        id: sync_linglong
+        shell: python
+        env:
+          VERSION: ${{ steps.prepare.outputs.version }}
+          CURRENT_VERSION: ${{ steps.prepare.outputs.current_version }}
+        run: |
+          import os
+          import pathlib
+          import re
+
+          version = os.environ["VERSION"].strip()
+          current_version = os.environ["CURRENT_VERSION"].strip()
+          repo_root = pathlib.Path(os.environ["GITHUB_WORKSPACE"])
+
+          def write_output(files):
+              if len(files) == 1:
+                  with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+                      fh.write(f"files={files[0]}\n")
+              else:
+                  delimiter = "CHANGELOGFILES"
+                  with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+                      fh.write(f"files<<{delimiter}\n")
+                      for item in files:
+                          fh.write(item + "\n")
+                      fh.write(delimiter + "\n")
+
+          def strip_epoch(value):
+              if ":" in value:
+                  _, value = value.split(":", 1)
+              return value
+
+          current_base = strip_epoch(current_version)
+
+          targets = sorted(repo_root.glob("linglong*.yaml"))
+          if not targets:
+              print("no linglong*.yaml found, skip")
+              write_output(["debian/changelog"])
+              raise SystemExit(0)
+
+          changed = []
+          for path in targets:
+              lines = path.read_text(encoding="utf-8").splitlines()
+              package_start = next(
+                  (i for i, line in enumerate(lines) if re.match(r"^package:\s*$", line)),
+                  None,
+              )
+              if package_start is None:
+                  print(f"skip {path}: no package block")
+                  continue
+
+              updated = False
+              for i, line in enumerate(lines):
+                  if i <= package_start:
+                      continue
+                  if re.match(r"^\S", line):
+                      break
+                  m = re.match(r"^(\s*version:\s*)(\S+)\s*$", line)
+                  if not m:
+                      continue
+                  old = m.group(2).strip()
+                  old_base = strip_epoch(old)
+                  parts = old_base.split(".")
+                  new_val = old
+                  if (
+                      len(parts) > 1
+                      and parts[-1].isdigit()
+                      and ".".join(parts[:-1]) == current_base
+                  ):
+                      new_val = f"{version}.{parts[-1]}"
+                  elif old_base == current_base:
+                      new_val = version
+                  if new_val != old:
+                      lines[i] = m.group(1) + new_val
+                      updated = True
+                      print(f"bump {path} version: {old} -> {new_val}")
+
+              if updated:
+                  path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+                  changed.append(path.name)
+
+          if changed:
+              write_output(["debian/changelog"] + changed)
+          else:
+              write_output(["debian/changelog"])
+
       - name: Show changelog diff
         if: ${{ !inputs.create_pr }}
-        run: git diff -- debian/changelog
+        run: git diff -- debian/changelog linglong*.yaml
 
       - name: Upload generated changelog
         if: ${{ !inputs.create_pr }}
         uses: actions/upload-artifact@v4
         with:
           name: generated-changelog
-          path: debian/changelog
+          path: |
+            debian/changelog
+            linglong*.yaml
 
       - name: Create pull request
         id: create_pr
@@ -298,8 +387,7 @@ jobs:
             - Base branch: `${{ steps.prepare.outputs.base_branch }}`
             - Base changelog commit: `${{ steps.prepare.outputs.base_sha }}`
             - Head commit: `${{ steps.prepare.outputs.head_sha }}`
-          add-paths: |
-            debian/changelog
+          add-paths: ${{ steps.sync_linglong.outputs.files }}
           delete-branch: true
 
       - name: Show pull request result

--- a/repos/linuxdeepin/dde-calendar.json
+++ b/repos/linuxdeepin/dde-calendar.json
@@ -90,5 +90,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-calendar/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/snipe"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-calendar/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-cooperation.json
+++ b/repos/linuxdeepin/dde-cooperation.json
@@ -57,5 +57,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-cooperation/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-cooperation/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-device-formatter.json
+++ b/repos/linuxdeepin/dde-device-formatter.json
@@ -82,5 +82,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-device-formatter/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-device-formatter/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-file-manager.json
+++ b/repos/linuxdeepin/dde-file-manager.json
@@ -109,5 +109,13 @@
     ],
     "src": "workflow-templates/call-static-check.yml",
     "dest": "linuxdeepin/dde-file-manager/.github/workflows/call-static-check.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/snipe"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-file-manager/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/dde-grand-search.json
+++ b/repos/linuxdeepin/dde-grand-search.json
@@ -81,5 +81,15 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/dde-grand-search/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "develop/snipe",
+      "release/snipe",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/dde-grand-search/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-album.json
+++ b/repos/linuxdeepin/deepin-album.json
@@ -90,5 +90,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-album/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-album/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-anything.json
+++ b/repos/linuxdeepin/deepin-anything.json
@@ -74,5 +74,14 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-anything/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "develop/snipe",
+      "release/snipe"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-anything/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-boot-maker.json
+++ b/repos/linuxdeepin/deepin-boot-maker.json
@@ -90,5 +90,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-boot-maker/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-boot-maker/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-calculator.json
+++ b/repos/linuxdeepin/deepin-calculator.json
@@ -90,5 +90,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-calculator/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-calculator/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-camera.json
+++ b/repos/linuxdeepin/deepin-camera.json
@@ -98,5 +98,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-camera/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-camera/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-compressor.json
+++ b/repos/linuxdeepin/deepin-compressor.json
@@ -90,5 +90,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-compressor/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-compressor/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-deb-installer.json
+++ b/repos/linuxdeepin/deepin-deb-installer.json
@@ -91,5 +91,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-deb-installer/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-deb-installer/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-devicemanager.json
+++ b/repos/linuxdeepin/deepin-devicemanager.json
@@ -90,5 +90,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-devicemanager/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-devicemanager/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-diskmanager.json
+++ b/repos/linuxdeepin/deepin-diskmanager.json
@@ -90,5 +90,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-diskmanager/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "develop/snipe"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-diskmanager/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-downloader.json
+++ b/repos/linuxdeepin/deepin-downloader.json
@@ -90,5 +90,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-downloader/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-downloader/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-draw.json
+++ b/repos/linuxdeepin/deepin-draw.json
@@ -90,5 +90,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-draw/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-draw/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-editor.json
+++ b/repos/linuxdeepin/deepin-editor.json
@@ -90,5 +90,15 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-editor/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "develop/snipe",
+      "release/snipe",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-editor/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-fcitx5configtool-plugin.json
+++ b/repos/linuxdeepin/deepin-fcitx5configtool-plugin.json
@@ -81,5 +81,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-fcitx5configtool-plugin/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-fcitx5configtool-plugin/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-font-manager.json
+++ b/repos/linuxdeepin/deepin-font-manager.json
@@ -90,5 +90,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-font-manager/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-font-manager/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-gomoku.json
+++ b/repos/linuxdeepin/deepin-gomoku.json
@@ -90,5 +90,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-gomoku/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-gomoku/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-image-viewer.json
+++ b/repos/linuxdeepin/deepin-image-viewer.json
@@ -90,5 +90,14 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-image-viewer/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/snipe",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-image-viewer/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-lianliankan.json
+++ b/repos/linuxdeepin/deepin-lianliankan.json
@@ -90,5 +90,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-lianliankan/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-lianliankan/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-log-viewer.json
+++ b/repos/linuxdeepin/deepin-log-viewer.json
@@ -90,5 +90,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-log-viewer/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-log-viewer/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-manual.json
+++ b/repos/linuxdeepin/deepin-manual.json
@@ -88,5 +88,14 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-manual/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "develop/snipe",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-manual/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-movie-reborn.json
+++ b/repos/linuxdeepin/deepin-movie-reborn.json
@@ -88,5 +88,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-movie-reborn/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-movie-reborn/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-music.json
+++ b/repos/linuxdeepin/deepin-music.json
@@ -98,5 +98,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-music/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-music/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-ocr.json
+++ b/repos/linuxdeepin/deepin-ocr.json
@@ -90,5 +90,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-ocr/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-ocr/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-picker.json
+++ b/repos/linuxdeepin/deepin-picker.json
@@ -90,5 +90,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-picker/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-picker/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-reader.json
+++ b/repos/linuxdeepin/deepin-reader.json
@@ -81,5 +81,14 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-reader/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/snipe",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-reader/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-scanner.json
+++ b/repos/linuxdeepin/deepin-scanner.json
@@ -1,0 +1,9 @@
+[
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-scanner/.github/workflows/call-update-changelog.yml"
+  }
+]

--- a/repos/linuxdeepin/deepin-screen-recorder.json
+++ b/repos/linuxdeepin/deepin-screen-recorder.json
@@ -81,5 +81,14 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-screen-recorder/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/snipe",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-screen-recorder/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-shortcut-viewer.json
+++ b/repos/linuxdeepin/deepin-shortcut-viewer.json
@@ -63,5 +63,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-shortcut-viewer/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-shortcut-viewer/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-system-monitor.json
+++ b/repos/linuxdeepin/deepin-system-monitor.json
@@ -81,5 +81,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-system-monitor/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-system-monitor/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-terminal.json
+++ b/repos/linuxdeepin/deepin-terminal.json
@@ -72,5 +72,13 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-terminal/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-terminal/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/deepin-voice-note.json
+++ b/repos/linuxdeepin/deepin-voice-note.json
@@ -90,5 +90,15 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/deepin-voice-note/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "develop/snipe",
+      "release/snipe",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/deepin-voice-note/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/docparser.json
+++ b/repos/linuxdeepin/docparser.json
@@ -90,5 +90,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/docparser/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/docparser/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/image-editor.json
+++ b/repos/linuxdeepin/image-editor.json
@@ -90,5 +90,12 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/image-editor/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/image-editor/.github/workflows/call-update-changelog.yml"
   }
 ]

--- a/repos/linuxdeepin/udisks2-qt6.json
+++ b/repos/linuxdeepin/udisks2-qt6.json
@@ -1,0 +1,9 @@
+[
+  {
+    "branch": [
+      "master"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/udisks2-qt6/.github/workflows/call-update-changelog.yml"
+  }
+]

--- a/repos/linuxdeepin/util-dfm.json
+++ b/repos/linuxdeepin/util-dfm.json
@@ -74,5 +74,14 @@
       ".github/workflows/call-tag-build.yml"
     ],
     "dest": "linuxdeepin/util-dfm/.github/workflows/call-tag-build.yml"
+  },
+  {
+    "branch": [
+      "master",
+      "release/snipe",
+      "release/eagle"
+    ],
+    "src": "workflow-templates/call-update-changelog.yml",
+    "dest": "linuxdeepin/util-dfm/.github/workflows/call-update-changelog.yml"
   }
 ]


### PR DESCRIPTION
## Summary

1. **update-changelog.yml**: auto-detect `linglong*.yaml` in repo root. If `package.version`'s base version matches the current changelog version, sync it with the new changelog version, keeping the numeric suffix (e.g. `7.0.64.1` → `7.0.65.1`). Projects with independent linglong versions are skipped automatically.

2. **App repos**: add `call-update-changelog.yml` entries to 39 linuxdeepin app repos (38 appended + 2 new configs for deepin-scanner and udisks2-qt6). Branch lists were verified against actual remote branches (`master`/`develop/snipe`/`release/snipe`/`release/eagle`).

## Testing

Verified on peeweep-test/dtkcore-test:
- changelog `5.6.23` + linglong `5.6.23.1` → PR updates both to `5.6.24` / `5.6.24.1` ✓
- changelog `5.6.23` + independent linglong `5.6.3` → linglong skipped, changelog only ✓

Log: sync linglong version in changelog update workflow for app repos
Influence: update-changelog workflow for app projects

## Summary by Sourcery

Keep compatible linglong package versions aligned with changelog updates and expand workflow configuration across LinuxDeepin application repositories.

New Features:
- Synchronize matching linglong package versions with changelog releases while preserving numeric suffixes and skipping independently versioned packages.
- Enable automated changelog update workflow coverage for additional LinuxDeepin application repositories, including deepin-scanner and udisks2-qt6.

Enhancements:
- Include synchronized linglong manifest files in generated diffs, artifacts, and pull requests.