### PR TITLE
harden: this workflow uses `secrets: inherit` to pass a... in...

### DIFF
--- a/workflow-templates/backup-to-gitlab.yml
+++ b/workflow-templates/backup-to-gitlab.yml
@@ -8,8 +8,10 @@ concurrency:
 jobs:
   backup-to-gitlabwh:
     uses: linuxdeepin/.github/.github/workflows/backup-to-gitlabwh.yml@master
-    secrets: inherit
+    secrets:
+      BRIDGETOKEN: ${{ secrets.BRIDGETOKEN }}
 
   backup-to-gitee:
     uses: linuxdeepin/.github/.github/workflows/backup-to-gitee.yml@master
-    secrets: inherit
+    secrets:
+      GITEE_SYNC_TOKEN: ${{ secrets.GITEE_SYNC_TOKEN }}


### PR DESCRIPTION
## Summary
Harden input handling in `workflow-templates/backup-to-gitlab.yml` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.github-actions.security.secrets-inherit.secrets-inherit |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `yaml.github-actions.security.secrets-inherit.secrets-inherit` |
| **File** | `workflow-templates/backup-to-gitlab.yml:11` |
| **Assessment** | Defensive hardening |

**Description**: This workflow uses `secrets: inherit` to pass all of the calling workflow's secrets to a reusable workflow. This violates the principle of least privilege because the called workflow receives access to every secret in the repository, not just the ones it needs. If the called workflow is compromised or sourced from a third party, an attacker gains access to all repository secrets. Instead, explicitly pass only the secrets that the called workflow requires using the `secrets:` map, e.g. `secrets: { MY_SECRET: ${{ secrets.MY_SECRET }} }`.

## Changes
- `workflow-templates/backup-to-gitlab.yml`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

## Summary by Sourcery

Limit secrets passed to backup workflows to reduce unintended credential exposure.

Bug Fixes:
- Restrict reusable backup workflows to the specific GitLab and Gitee credentials they require instead of inheriting all repository secrets.

Enhancements:
- Harden workflow secret handling according to least-privilege principles.