### PR TITLE
fix: checkout merge commit for merged PRs in auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: refs/heads/${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.merged && github.event.pull_request.merge_commit_sha || format('refs/heads/{0}', github.event.pull_request.head.ref) }}
+          repository: ${{ github.event.pull_request.merged && github.event.repository.full_name || github.event.pull_request.head.repo.full_name }}
           allow-unsafe-pr-checkout: true
           persist-credentials: false
       - name: get changelog version


### PR DESCRIPTION
# 问题

当 PR 来自 fork 且合并后 fork 分支被删除时，auto-tag workflow 的 `actions/checkout@v7` 步骤会失败，因为：

1. PR 被合并后，workflow 由 `pull_request_target: closed` 触发
2. `ref: refs/heads/${{ github.event.pull_request.head.ref }}` 指向 fork 中的分支
3. fork 的分支在 merge 后被删除，checkout 无法找到该 ref
4. `repository: ${{ github.event.pull_request.head.repo.full_name }}` 指向 fork 而非 base repo

## 修复

在 `actions/checkout@v7` 中增加条件判断：

- **PR 已合并（merged=true）**：从 base repo（`github.event.repository.full_name`）检出 `merge_commit_sha`，该 commit 永久存在于 base repo 中
- **PR 未合并（opened/synchronize）**：保持原有行为，从 fork 检出分支 ref

## 变更文件

| 文件 | 修改处数 |
|------|---------|
| `.github/workflows/auto-tag.yml` | 1 |

## 相关 Issue

- linuxdeepin/treeland#1312 auto-tag workflow checkout failure after merge (branch deleted from fork)

## Summary by Sourcery

Bug Fixes:
- Ensure the auto-tag workflow can check out merged pull requests even when the source fork branch has been deleted.