### PR TITLE
chore: update deepin-kernel team members and permissions

### DIFF
--- a/teams.yaml
+++ b/teams.yaml
@@ -836,9 +836,12 @@ teams:
       - xzl01
       - zccrs
       - Zeno-sole
+      - dongert
+      - f-jye
     repositories_permissions:
       push:
         - deepin-lkrg
+        - asterinas
   - name: migration-tools
     parent_team: Maintainers
     members:


### PR DESCRIPTION
Update the deepin-kernel team members and add asterinas push permission.

## Summary by Sourcery

Enhancements:
- Update the deepin-kernel team roster and grant it push access to the asterinas repository.